### PR TITLE
Potential fix for code scanning alert no. 4: Server-side request forgery

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,6 +33,18 @@ const CACHE = {
 	people: 'public, max-age=300, stale-while-revalidate=120'
 };
 
+function validateNumericId(id) {
+	if (typeof id !== 'string') {
+		return null;
+	}
+	const trimmed = id.trim();
+	// Only allow positive integer IDs to be used in upstream paths.
+	if (!/^[0-9]+$/.test(trimmed)) {
+		return null;
+	}
+	return trimmed;
+}
+
 function pipeMlbToResponse(upstream, res, cacheControl) {
 	const ct = upstream.headers['content-type'];
 	if (ct) {
@@ -75,7 +87,12 @@ app.get('/teams', (req, res) => {
 });
 
 app.get('/teams/:teamId/roster', (req, res) => {
-	proxyMlb(req, res, `teams/${req.params.teamId}/roster`, CACHE.roster);
+	const teamId = validateNumericId(req.params.teamId);
+	if (!teamId) {
+		res.status(400).json({ message: 'Invalid teamId' });
+		return;
+	}
+	proxyMlb(req, res, `teams/${teamId}/roster`, CACHE.roster);
 });
 
 /** Comma-separated MLB person IDs → single MLB batch request (personIds query). */
@@ -96,7 +113,12 @@ app.get('/people/:playerId', (req, res) => {
 		res.status(400).json({ message: parsed.message });
 		return;
 	}
-	proxyMlb(req, res, `people/${req.params.playerId}`, CACHE.people);
+	const playerId = validateNumericId(req.params.playerId);
+	if (!playerId) {
+		res.status(400).json({ message: 'Invalid playerId' });
+		return;
+	}
+	proxyMlb(req, res, `people/${playerId}`, CACHE.people);
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
Potential fix for [https://github.com/danibsheehan/baseball-collection/security/code-scanning/4](https://github.com/danibsheehan/baseball-collection/security/code-scanning/4)

General fix: Ensure any user input used to construct `relativePath` is strictly validated and normalized so it cannot contain path separators (`/`, `\`), dot segments (`.`, `..`), query delimiters (`?`, `#`, `&`), or other characters that could alter the intended endpoint. For identifiers like `teamId` and `playerId`, the safest approach is to restrict them to a known-safe format (for example, digits only) and reject or sanitize anything else before calling `proxyMlb`.

Best fix here without changing existing functionality:

1. Introduce a small, local validator function (in `server.js`) that:
   - Accepts a string identifier.
   - Checks that it matches a strict pattern (for example, `/^[0-9]+$/`).
   - Returns `null` or throws on invalid input.
2. Use this validator on `req.params.teamId` and `req.params.playerId` *before* they are interpolated into the path passed to `proxyMlb`.
3. If validation fails, respond with HTTP 400 and a clear error message and do not call `proxyMlb`.

This keeps the existing path structure (`teams/<id>/roster`, `people/<id>`) and behavior for valid numeric IDs, and only blocks potentially malicious or malformed inputs. All changes can be done within `server.js`: adding the validator near the top and slightly modifying the two affected route handlers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
