### PR TITLE
Add pr-ready Cursor skill

### DIFF
--- a/.cursor/skills/pr-ready/SKILL.md
+++ b/.cursor/skills/pr-ready/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: pr-ready
+description: >
+  Runs baseball-collection local CI-parity checks and prepares a pull request
+  (lint, Vitest coverage thresholds, build, Pages env when needed). Use when the
+  user asks to open a PR, prepare a pull request, pre-PR checks, make CI pass,
+  or verify before merging.
+---
+
+# PR ready (baseball-collection)
+
+Run before opening or updating a PR. Prefer full gates over “tests only.”
+
+## Checklist
+
+```
+Pre-PR:
+- [ ] Scope: only intended files; no secrets (.env, credentials)
+- [ ] npm run lint
+- [ ] npm run test:coverage
+- [ ] npm run build
+- [ ] Pages-shaped build if deploy/base/API env changed
+- [ ] PR summary ready (Summary + Test plan)
+```
+
+### 1. Local CI parity
+
+From the repo root:
+
+```bash
+npm run lint
+npm run test:coverage
+npm run build
+```
+
+| Check | Why |
+|-------|-----|
+| `lint` | ESLint on `src` (`.vue`, `.ts`) — good local gate even though unit-test CI focuses on coverage |
+| `test:coverage` | Matches **`.github/workflows/pull-request-tests.yml`**; enforces Vitest thresholds in `vite.config.mjs` |
+| `build` | Catches Vite/bundle breaks before Pages or Node hosting |
+
+Faster while iterating (not a substitute before PR): `npm run test:run`.
+
+If the change touches **`VITE_PUBLIC_PATH`**, **`VITE_API_BASE`**, Pages workflow, or subpath asset loading, also follow **`.cursor/skills/github-pages-deploy/SKILL.md`** (CI-shaped `build` + spot-check `preview`).
+
+Proxy / validation work: confirm tests under `lib/**/*.test.mjs` still pass via coverage run; see **`api-proxy-hardening`**.
+
+### 2. PR description
+
+There is no repo PR template file; still include:
+
+- **Summary** — what changed and why (1–3 bullets)
+- **Test plan** — commands run (`lint` / `test:coverage` / `build`) and UI paths to exercise (team picker, roster deal, card flip), or `N/A` for tooling-only
+
+Do not push or create the PR unless the user asked.
+
+### 3. After merge (local cleanup)
+
+When the PR is merged and the user is done with the branch (or asks to clean up):
+
+```bash
+git checkout main && git pull origin main
+git branch -d <feature-branch>
+```
+
+Optionally `git fetch --prune` for stale remote-tracking refs.
+
+## Anti-patterns
+
+- Opening a PR after only `test:run` when coverage thresholds matter.
+- Skipping `build` after Vite, dependency, or asset changes.
+- Committing `.env*` or tokens.
+- Amending or force-pushing unless the user explicitly requests it.
+- Leaving merged feature branches checked out after the user asks to clean up.


### PR DESCRIPTION
## Summary
- Adds `.cursor/skills/pr-ready/SKILL.md` for local CI-parity before opening a PR (`lint`, `test:coverage`, `build`)
- Covers PR summary fields and post-merge branch cleanup notes

## Test plan
- [ ] Confirm checklist commands match `package.json` and `.github/workflows/pull-request-tests.yml`
- [ ] No app/runtime code changes (Cursor metadata only)

Made with [Cursor](https://cursor.com)