### PR TITLE
Thin always-on Cursor project rule

### DIFF
--- a/.cursor/rules/baseball-collection.mdc
+++ b/.cursor/rules/baseball-collection.mdc
@@ -1,5 +1,5 @@
 ---
-description: Vue/Vite app conventions, MLB proxy server, tests, and env for baseball-collection (Cartophiles UI)
+description: Vue/Vite app conventions, MLB proxy, and agent done criteria for baseball-collection (Cartophiles)
 alwaysApply: true
 ---
 
@@ -9,42 +9,40 @@ Vue 3 + Vite SPA (album shell, roster grid, card flip/tilt/foil, wax-pack deal) 
 
 ## Layout
 
-- **Cursor**: `.cursor/rules/` (always-on project rule), `.cursor/skills/` (optional Agent skills: `doc-writer`, `test-generator`, `github-pages-deploy`, `bundle-performance`, `api-proxy-hardening`, `accessibility-a11y` — each folder has `SKILL.md`).
-- **UI**: `src/` — `main.ts`, `App.vue`, `components/*.vue`, shared logic in `src/lib/` (`.ts`, tests colocated as `*.test.ts`).
-- **Global look**: `src/styles/tokens.css` (newsprint, album layers, motion tokens); `src/styles/team-themes.css` (`[data-theme]` on **BaseballCard**).
-- **HTTP client**: `src/http-common.ts` (Axios + short-lived cache); `src/lib/rosterPeople.ts` batches people for card backs.
-- **API**: `server.js` — Express, `dotenv`, axios proxy toward MLB Stats API v1; shared validation under `lib/` (e.g. `peopleQueryValidation` consumed as `.cjs` from the server).
-- **Tooling**: `vite.config.mjs` (Vue plugin, Vitest `environment: 'node'`, dev proxy to `127.0.0.1:3000` for `/teams` and `/people`), `scripts/bundle-report.mjs`, static assets under `public/`.
+- **UI**: `src/` — `main.ts`, `App.vue`, `components/*.vue`, shared logic in `src/lib/` (`.ts`, tests as `*.test.ts`).
+- **Global look**: `src/styles/tokens.css`; team themes in `src/styles/team-themes.css` (`[data-theme]` on **BaseballCard**).
+- **HTTP**: `src/http-common.ts` (Axios + short-lived cache); `src/lib/rosterPeople.ts` batches people for card backs.
+- **API**: `server.js` + validation under `lib/` — details in skill **`api-proxy-hardening`**.
+- **Tooling**: `vite.config.mjs` (Vue, Vitest `environment: 'node'`, dev proxy to `127.0.0.1:3000` for `/teams` and `/people`).
 
 ## Commands
 
-- **Dev**: `npm run dev` — `concurrently` runs `npm run api` (**PORT=3000**) and Vite (**http://localhost:5173**); `npm run dev:client` is Vite only if the proxy is already running.
-- **API only**: `npm run api` — Express on port **3000**.
-- **Lint**: `npm run lint` — ESLint on `src` for `.vue`, `.ts` (see `package.json`).
-- **Tests**: `npm run test` / `npm run test:run` — Vitest; `npm run test:coverage` (thresholds, HTML + `cobertura-coverage.xml` under `coverage/`); `npm run test:coverage:watch` for local watch. Include patterns in `vite.config.mjs` (`src/**/*.test.ts`, `lib/**/*.test.mjs`). PRs and pushes to `main` run coverage via `.github/workflows/pull-request-tests.yml` (job summary: `irongut/CodeCoverageSummary`; same-repo PR comment: `5monkeys/cobertura-action`).
-- **Build**: `npm run build`; optional size check: `npm run build:report`.
-- **Preview**: `npm run preview` — Vite preview (`VITE_API_BASE` baked at build time).
-- **Prod-like local**: `npm start` — `node server.js` serves `dist` + proxy routes (**PORT** default **8080**).
-- **Heroku**: `npm run heroku-postbuild` — dev deps + build for deploy.
-- **GitHub Pages**: push to `main` runs `.github/workflows/deploy-pages.yml` (see skill `github-pages-deploy` for env parity and checks).
-
-After non-trivial changes, run **lint** and **tests** when feasible; run **build** for dependency or bundling-sensitive edits.
+- **Dev**: `npm run dev` (API **:3000** + Vite **:5173**); `npm run api` / `npm run dev:client` alone as needed.
+- **Lint / test / build**: `npm run lint`, `npm run test` / `test:run` / `test:coverage`, `npm run build` (optional `build:report`).
+- **Prod-like**: `npm start` serves `dist` + proxy (**PORT** default **8080**).
+- **Pages**: push to `main` → `.github/workflows/deploy-pages.yml` (skill **`github-pages-deploy`**).
 
 ## Conventions
 
-- Match existing **Vue SFC** style and patterns in nearby components (e.g. `PlayerInfo.vue`, `BaseballCard.vue`).
-- Prefer **focused diffs**; do not refactor unrelated code or add unsolicited README/docs.
-- **New or changed logic** in `src/lib/` or `lib/`: add or extend **Vitest** coverage when behavior is non-trivial.
+- Match nearby **Vue SFC** patterns (`PlayerInfo.vue`, `BaseballCard.vue`).
+- Prefer **focused diffs**; no unsolicited README/docs or drive-by refactors.
+- Non-trivial logic in `src/lib/` or `lib/`: add or extend **Vitest** coverage.
+- Client env: **`VITE_`** prefix only. Do not commit secrets (`.env*` stay local).
+- **`VITE_API_BASE`**: MLB Stats API root (empty in dev → same-origin via Vite → Express). **`VITE_PUBLIC_PATH`**: Vite `base` for project Pages.
 
-## Environment and secrets
+## Agent definition of done
 
-- Do not commit real API keys or personal tokens. Treat `.env`, `.env.local`, `.env.production`, and similar as **local-only**; suggest `.gitignore` if env files are ever tracked by mistake.
-- Client env vars exposed to the browser must use the **`VITE_`** prefix (see `vite.config.mjs` / `loadEnv`).
-- **`VITE_API_BASE`**: full MLB Stats API root, e.g. `https://statsapi.mlb.com/api/v1`. Empty in dev → same-origin `/teams` and `/people` via Vite → Express.
-- **`VITE_PUBLIC_PATH`**: Vite `base`; `/repository-name/` for GitHub project Pages.
-- **`PORT`**: `server.js` listen port (**8080** default for `npm start`; `npm run api` forces **3000**).
+- **Task done**: follow skills for files you touched; run the **smallest** relevant check. For substantive edits, follow **`.cursor/skills/definition-of-done/SKILL.md`** (`lint` → `test:run` → `build`). Do **not** require full CI for every small edit.
+- **PR done**: follow **`.cursor/skills/pr-ready/SKILL.md`** (`lint`, `test:coverage`, `build`; Pages-shaped build when deploy/env changes). Commit, push, or open a PR **only when the user asks**.
 
-## Server behavior (summary)
+## Workflow skills
 
-- Proxies: `GET /teams`, `GET /teams/:teamId/roster`, `GET /people` (batch up to **50** IDs via `personIds` or **`ids`** — comma-separated), `GET /people/:playerId` — streaming responses with cache headers. Invalid query/path params return **400** with a JSON `message`; upstream failures **502**.
-- Upstream contract matches **MLB Stats API** (`https://statsapi.mlb.com/api/v1/` in docs and `VITE_API_BASE`; axios `baseURL` in `server.js` is the implementation detail).
+Read `.cursor/skills/<name>/SKILL.md` when the task fits:
+
+- **`definition-of-done`** / **`pr-ready`** — validate a task or prepare a PR
+- **`api-proxy-hardening`** — Express proxy, validation, CORS/cache, `VITE_API_BASE` modes
+- **`github-pages-deploy`** — Pages base path, `VITE_*` CI parity
+- **`test-generator`** — Vitest for Vue/TS
+- **`accessibility-a11y`** — keyboard, ARIA, reduced motion
+- **`bundle-performance`** — size report, Lottie/chunk weight
+- **`doc-writer`** — README / JSDoc (keep palette tables in sync with `tokens.css`)


### PR DESCRIPTION
## Summary
- Thins `.cursor/rules/baseball-collection.mdc` to layout, key commands, conventions, and task vs PR done criteria
- Indexes Cursor skills (including definition-of-done and pr-ready) instead of duplicating proxy/env detail

## Test plan
- [ ] Prefer merging after the definition-of-done and pr-ready skill PRs so named skills exist
- [ ] Spot-check the rule still points at the right skill folders
- [ ] No app/runtime code changes (Cursor metadata only)

Made with [Cursor](https://cursor.com)