### PR TITLE
Add Dependabot for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Weekly version updates for npm and GitHub Actions.
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    # Scans .github/workflows (and root action manifests).
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Add weekly Dependabot updates for `npm` and `github-actions` (limit 10 open PRs each), matching the pattern used in gotta-catch-em-all.

## Test plan
- [ ] Confirm Dependabot shows as enabled under repo Settings → Code security
- [ ] After merge, expect Dependabot PRs on the weekly schedule (or trigger a version update check)


Made with [Cursor](https://cursor.com)