### PR TITLE
Harden CI workflow hygiene (Node, concurrency, Actions)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -11,23 +11,23 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
           cache: npm
       - run: npm ci
       - run: npm run build
         env:
           VITE_API_BASE: https://statsapi.mlb.com/api/v1
           VITE_PUBLIC_PATH: /${{ github.event.repository.name }}/
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -38,5 +38,5 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -11,14 +11,18 @@ permissions:
   pull-requests: write
   checks: write
 
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
           cache: npm
       - run: npm ci
       - name: Unit tests and coverage thresholds


### PR DESCRIPTION
## Summary
- Read Node from `.nvmrc` instead of a hardcoded `22`
- Cancel overlapping unit-test runs via concurrency
- Bump `checkout` / `setup-node` to v7 and Pages upload/deploy to v5
- Set Pages deploy `cancel-in-progress: false` so mid-deploy cancels don’t leave a bad site

## Test plan
- [ ] Unit tests workflow passes on this PR
- [ ] After merge to `main`, Deploy to GitHub Pages succeeds with the newer Actions
- [ ] Confirm Node version in CI logs matches `.nvmrc`


Made with [Cursor](https://cursor.com)