### PR TITLE
Run lint and Pages-shaped build in PR CI

### DIFF
--- a/.cursor/skills/pr-ready/SKILL.md
+++ b/.cursor/skills/pr-ready/SKILL.md
@@ -35,9 +35,9 @@ npm run build
 
 | Check | Why |
 |-------|-----|
-| `lint` | ESLint on `src` (`.vue`, `.ts`) — good local gate even though unit-test CI focuses on coverage |
-| `test:coverage` | Matches **`.github/workflows/pull-request-tests.yml`**; enforces Vitest thresholds in `vite.config.mjs` |
-| `build` | Catches Vite/bundle breaks before Pages or Node hosting |
+| `lint` | ESLint on `src` (`.vue`, `.ts`) — same gate as **`.github/workflows/pull-request-tests.yml`** |
+| `test:coverage` | Matches CI; enforces Vitest thresholds in `vite.config.mjs` |
+| `build` | Matches CI (Pages-shaped `VITE_*` in the workflow); catches Vite/bundle breaks before Pages or Node hosting |
 
 Faster while iterating (not a substitute before PR): `npm run test:run`.
 

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -25,8 +25,15 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+      - name: Lint
+        run: npm run lint
       - name: Unit tests and coverage thresholds
         run: npm run test:coverage
+      - name: Production build
+        run: npm run build
+        env:
+          VITE_API_BASE: https://statsapi.mlb.com/api/v1
+          VITE_PUBLIC_PATH: /${{ github.event.repository.name }}/
       - name: Cobertura markdown summary (for job summary)
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:


### PR DESCRIPTION
## Summary
- Expand the unit-test workflow to run `lint` → `test:coverage` → Pages-shaped `build` (`VITE_API_BASE` + `VITE_PUBLIC_PATH`)
- Update the pr-ready skill so local checks match what CI enforces

## Test plan
- [ ] This PR’s Unit tests workflow runs the new Lint and Production build steps and passes
- [ ] Locally: `npm run lint && npm run test:coverage && VITE_API_BASE=https://statsapi.mlb.com/api/v1 VITE_PUBLIC_PATH=/baseball-collection/ npm run build` (already green)
- [ ] If merging after #75, resolve any small workflow hunk overlap (should be clean)


Made with [Cursor](https://cursor.com)