### PR TITLE
Add a light pull request template

### DIFF
--- a/.cursor/skills/pr-ready/SKILL.md
+++ b/.cursor/skills/pr-ready/SKILL.md
@@ -47,10 +47,10 @@ Proxy / validation work: confirm tests under `lib/**/*.test.mjs` still pass via 
 
 ### 2. PR description
 
-There is no repo PR template file; still include:
+Use the repo PR template (`.github/pull_request_template.md`):
 
 - **Summary** — what changed and why (1–3 bullets)
-- **Test plan** — commands run (`lint` / `test:coverage` / `build`) and UI paths to exercise (team picker, roster deal, card flip), or `N/A` for tooling-only
+- **How to verify** — commands run (`lint` / `test:coverage` / `build`) and UI paths to exercise (team picker, roster deal, card flip), or `N/A` for tooling-only
 
 Do not push or create the PR unless the user asked.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- What changed and why (user-visible behavior, API, or tooling). -->
+
+## How to verify
+
+<!-- e.g. UI paths to exercise, or commands run (`lint` / `test:coverage` / `build`), or "N/A" for docs-only. -->


### PR DESCRIPTION
## Summary
- Add `.github/pull_request_template.md` with Summary and How to verify
- Update the pr-ready skill to reference the template

## Test plan
- [ ] Open a draft PR from a throwaway branch (or inspect the “Create pull request” form) and confirm the template body appears
- [ ] No workflow/app behavior change


Made with [Cursor](https://cursor.com)