### PR TITLE
Add shareable team URL state (?team=)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -125,11 +125,7 @@
 														:key="team.id"
 														:team="team"
 														:selected="selectedTeamId === team.id"
-														@updatePlayers="loadPlayers"
-														@updateTeam="loadTeam"
-														@liveMessage="setLiveMessage"
-														@rosterLoading="setRosterLoading"
-														@rosterLoadStage="setRosterLoadStage"
+														@select="onTeamSelect"
 													/>
 												</div>
 											</section>
@@ -295,11 +291,20 @@ import BaseballCard from './components/BaseballCard.vue';
 import Team from './components/Team.vue';
 import http from './http-common';
 import { filterMajorLeagueBaseballTeams } from './lib/filterMlbTeams';
+import { fetchEnrichedRoster } from './lib/rosterLoad';
 import {
 	buildTeamPickerSections,
 	filterTeamPickerSections
 } from './lib/teamPickerSections';
+import {
+	findTeamByTeamCode,
+	readTeamCodeFromLocation,
+	writeTeamCodeToHistory
+} from './lib/teamUrlState';
 import { useBinderPennantParallax } from './lib/useBinderPennantParallax';
+
+/** Bumps on each roster request so stale responses do not overwrite a newer club. */
+let rosterRequestId = 0;
 
 const players = ref([]);
 const teamName = ref('');
@@ -310,7 +315,7 @@ const teamsLoading = ref(true);
 const teamsError = ref('');
 const liveRegionText = ref('');
 const rosterLoading = ref(false);
-/** 'idle' | 'pulling' | 'faces' — from Team.vue while a roster request is in flight */
+/** 'idle' | 'pulling' | 'faces' — while a roster request is in flight */
 const rosterLoadStage = ref('idle');
 const resultsSection = ref(null);
 const binderRef = ref(null);
@@ -481,6 +486,7 @@ watch(
 );
 
 onUnmounted(() => {
+	window.removeEventListener('popstate', onTeamPopState);
 	if (dealCompleteTimer != null) {
 		clearTimeout(dealCompleteTimer);
 		dealCompleteTimer = null;
@@ -791,16 +797,6 @@ watch(
 	{ flush: 'post' }
 );
 
-function loadPlayers(nextPlayers) {
-	players.value = nextPlayers;
-}
-
-function loadTeam(team) {
-	selectedTeamId.value = team.id;
-	theme.value = team.teamCode?.toLowerCase() || '';
-	teamName.value = team.name;
-}
-
 function setLiveMessage(message) {
 	liveRegionText.value = message;
 }
@@ -816,7 +812,118 @@ function setRosterLoading(loading) {
 	}
 }
 
+function applySelectedTeam(team) {
+	selectedTeamId.value = team.id;
+	theme.value = team.teamCode?.toLowerCase() || '';
+	teamName.value = team.name;
+}
+
+function clearSelectedTeam() {
+	selectedTeamId.value = null;
+	theme.value = '';
+	teamName.value = '';
+	players.value = [];
+}
+
+/**
+ * Load a club roster (checklist click, URL hydrate, or browser history).
+ * @param {object} team
+ * @param {{ historyMode?: 'push' | 'replace' | 'none' }} [opts]
+ */
+async function selectTeam(team, opts = {}) {
+	const historyMode = opts.historyMode ?? 'push';
+	const requestId = ++rosterRequestId;
+
+	applySelectedTeam(team);
+	if (historyMode !== 'none') {
+		writeTeamCodeToHistory(team.teamCode?.toLowerCase() || null, historyMode);
+	}
+
+	players.value = [];
+	setLiveMessage(`Pulling the sheet for ${team.name}.`);
+	setRosterLoadStage('pulling');
+	setRosterLoading(true);
+
+	try {
+		const { players: nextPlayers, empty } = await fetchEnrichedRoster(http, team.id, {
+			onRosterLoaded: () => {
+				if (requestId === rosterRequestId) {
+					setRosterLoadStage('faces');
+				}
+			}
+		});
+		if (requestId !== rosterRequestId) {
+			return;
+		}
+		players.value = nextPlayers;
+		if (empty) {
+			setLiveMessage(`No pasteboards listed for ${team.name}.`);
+		} else {
+			setLiveMessage(
+				`Showing ${nextPlayers.length} ${nextPlayers.length === 1 ? 'card' : 'cards'} for ${team.name}.`
+			);
+		}
+	} catch {
+		if (requestId !== rosterRequestId) {
+			return;
+		}
+		players.value = [];
+		setLiveMessage(`Could not load the sheet for ${team.name}.`);
+	} finally {
+		if (requestId === rosterRequestId) {
+			setRosterLoading(false);
+		}
+	}
+}
+
+function onTeamSelect(team) {
+	if (team?.id == null) {
+		return;
+	}
+	const historyMode = selectedTeamId.value === team.id ? 'replace' : 'push';
+	selectTeam(team, { historyMode });
+}
+
+/**
+ * Apply `?team=` from the location (boot hydrate or popstate).
+ * @param {{ announceMissing?: boolean }} [opts]
+ */
+function syncTeamFromLocation(opts = {}) {
+	const announceMissing = opts.announceMissing !== false;
+	const code = readTeamCodeFromLocation();
+
+	if (!code) {
+		if (selectedTeamId.value != null) {
+			rosterRequestId += 1;
+			clearSelectedTeam();
+			setRosterLoading(false);
+			setLiveMessage('Club cleared. Pick one from the checklist to see the pasteboards.');
+		}
+		return;
+	}
+
+	const team = findTeamByTeamCode(teams.value, code);
+	if (!team) {
+		if (announceMissing) {
+			setLiveMessage(`No club on file for “${code}”.`);
+		}
+		writeTeamCodeToHistory(null, 'replace');
+		return;
+	}
+
+	if (selectedTeamId.value === team.id && (players.value.length > 0 || rosterLoading.value)) {
+		return;
+	}
+
+	selectTeam(team, { historyMode: 'none' });
+}
+
+function onTeamPopState() {
+	syncTeamFromLocation();
+}
+
 onMounted(() => {
+	window.addEventListener('popstate', onTeamPopState);
 	teams.value = [];
 	teamsLoading.value = true;
 	teamsError.value = '';
@@ -828,10 +935,18 @@ onMounted(() => {
 			);
 			teams.value = data;
 			teamsError.value = '';
-			liveRegionText.value =
-				data.length > 0
-					? `${data.length} clubs on file. Pick one from the checklist to see the pasteboards.`
-					: 'No teams available.';
+			const deepLinkCode = readTeamCodeFromLocation();
+			const deepLinkTeam = deepLinkCode ? findTeamByTeamCode(data, deepLinkCode) : undefined;
+			if (deepLinkTeam) {
+				liveRegionText.value = `Opening the sheet for ${deepLinkTeam.name}.`;
+			} else if (deepLinkCode) {
+				liveRegionText.value = `No club on file for “${deepLinkCode}”.`;
+			} else {
+				liveRegionText.value =
+					data.length > 0
+						? `${data.length} clubs on file. Pick one from the checklist to see the pasteboards.`
+						: 'No teams available.';
+			}
 		})
 		.catch((err) => {
 			console.error('teams request failed', err);
@@ -841,6 +956,9 @@ onMounted(() => {
 		})
 		.finally(() => {
 			teamsLoading.value = false;
+			nextTick(() => {
+				syncTeamFromLocation({ announceMissing: false });
+			});
 		});
 });
 </script>

--- a/src/components/Team.test.ts
+++ b/src/components/Team.test.ts
@@ -1,23 +1,11 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
 import Team from './Team.vue';
-
-const mockGet = vi.hoisted(() => vi.fn());
-
-vi.mock('../http-common', () => ({
-	default: {
-		get: mockGet
-	}
-}));
 
 const yankees = { id: 147, name: 'Yankees', teamCode: 'NYY' };
 
 describe('Team', () => {
-	beforeEach(() => {
-		mockGet.mockReset();
-	});
-
 	it('renders the team name', () => {
 		const wrapper = mount(Team, { props: { team: yankees } });
 		expect(wrapper.find('.team__name').text()).toBe('Yankees');
@@ -36,82 +24,9 @@ describe('Team', () => {
 		expect(wrapper.find('button').attributes('data-theme')).toBe('nyy');
 	});
 
-	it('loads roster and emits sorted players', async () => {
-		mockGet.mockImplementation((url: string) => {
-			if (url.includes('roster')) {
-				return Promise.resolve({
-					data: {
-						roster: [
-							{ person: { id: 2, fullName: 'B Player' } },
-							{ person: { id: 1, fullName: 'A Player' } }
-						]
-					}
-				});
-			}
-			if (url === 'people') {
-				return Promise.resolve({
-					data: {
-						people: [
-							{ id: 1, fullName: 'A Player' },
-							{ id: 2, fullName: 'B Player' }
-						]
-					}
-				});
-			}
-			return Promise.reject(new Error(`Unexpected URL: ${url}`));
-		});
-
+	it('emits select with the team on click', async () => {
 		const wrapper = mount(Team, { props: { team: yankees } });
 		await wrapper.find('button').trigger('click');
-		await flushPromises();
-
-		const updates = wrapper.emitted('updatePlayers');
-		expect(updates?.length).toBeGreaterThan(0);
-		const last = updates?.at(-1)?.[0] as Array<{ person?: { fullName?: string } }>;
-		expect(last?.map((r) => r.person?.fullName)).toEqual(['A Player', 'B Player']);
-		expect(wrapper.emitted('rosterLoading')?.flat().includes(false)).toBe(true);
-	});
-
-	it('uses singular copy when only one card is returned', async () => {
-		mockGet.mockImplementation((url: string) => {
-			if (url.includes('roster')) {
-				return Promise.resolve({
-					data: { roster: [{ person: { id: 10, fullName: 'Solo' } }] }
-				});
-			}
-			if (url === 'people') {
-				return Promise.resolve({ data: { people: [{ id: 10, fullName: 'Solo' }] } });
-			}
-			return Promise.reject(new Error(`Unexpected URL: ${url}`));
-		});
-
-		const wrapper = mount(Team, { props: { team: yankees } });
-		await wrapper.find('button').trigger('click');
-		await flushPromises();
-
-		expect(String(wrapper.emitted('liveMessage')?.at(-1)?.[0])).toContain('1 card for');
-	});
-
-	it('emits an empty roster when the API returns no people ids', async () => {
-		mockGet.mockResolvedValueOnce({ data: { roster: [{ person: {} }] } });
-
-		const wrapper = mount(Team, { props: { team: yankees } });
-		await wrapper.find('button').trigger('click');
-		await flushPromises();
-
-		const lastPlayers = wrapper.emitted('updatePlayers')?.at(-1)?.[0];
-		expect(lastPlayers).toEqual([]);
-		expect(String(wrapper.emitted('liveMessage')?.at(-1)?.[0])).toContain('No pasteboards');
-	});
-
-	it('emits empty players when roster request fails', async () => {
-		mockGet.mockRejectedValueOnce(new Error('network'));
-
-		const wrapper = mount(Team, { props: { team: yankees } });
-		await wrapper.find('button').trigger('click');
-		await flushPromises();
-
-		expect(wrapper.emitted('updatePlayers')?.at(-1)?.[0]).toEqual([]);
-		expect(String(wrapper.emitted('liveMessage')?.at(-1)?.[0])).toContain('Could not load');
+		expect(wrapper.emitted('select')?.[0]).toEqual([yankees]);
 	});
 });

--- a/src/components/Team.vue
+++ b/src/components/Team.vue
@@ -5,7 +5,7 @@
 		:class="{ 'team--selected': selected }"
 		:data-theme="theme || undefined"
 		:aria-current="selected ? 'true' : undefined"
-		@click="searchPlayers"
+		@click="onSelect"
 	>
 		<span class="team__inner">
 			<span class="team__logo" aria-hidden="true"></span>
@@ -15,15 +15,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
-import http from '../http-common';
-import {
-	PEOPLE_BATCH_SIZE,
-	uniquePersonIds,
-	chunkPersonIds,
-	peopleByIdFromResponses,
-	enrichRosterWithPlayerInfo
-} from '../lib/rosterPeople';
+import { computed } from 'vue';
 
 const props = defineProps({
 	team: {
@@ -35,65 +27,12 @@ const props = defineProps({
 	}
 });
 
-const emit = defineEmits(['updatePlayers', 'updateTeam', 'liveMessage', 'rosterLoading', 'rosterLoadStage']);
-
-const players = ref([]);
+const emit = defineEmits(['select']);
 
 const theme = computed(() => props.team.teamCode?.toLowerCase() || '');
 
-function fetchPeopleByIds(personIds) {
-	const unique = uniquePersonIds(personIds);
-	const chunks = chunkPersonIds(unique, PEOPLE_BATCH_SIZE);
-	return Promise.all(
-		chunks.map((chunk) =>
-			http.get('people', { params: { personIds: chunk.join(',') } })
-		)
-	)
-		.then((responses) => peopleByIdFromResponses(responses))
-		.catch(() => ({}));
-}
-
-function searchPlayers() {
-	players.value = [];
-	emit('updateTeam', props.team);
-	emit('updatePlayers', []);
-	emit('liveMessage', `Pulling the sheet for ${props.team.name}.`);
-	emit('rosterLoadStage', 'pulling');
-	emit('rosterLoading', true);
-
-	http.get(`teams/${props.team.id}/roster`)
-		.then((response) => {
-			const data = response.data.roster || [];
-			const ids = data.map((r) => r.person?.id).filter(Boolean);
-			if (!ids.length) {
-				emit('updatePlayers', []);
-				emit('liveMessage', `No pasteboards listed for ${props.team.name}.`);
-				return;
-			}
-			emit('rosterLoadStage', 'faces');
-			return fetchPeopleByIds(ids).then((byId) => {
-				const enriched = enrichRosterWithPlayerInfo(data, byId);
-				const sorted = [...enriched].sort((a, b) => {
-					const an = String(a.playerInfo?.fullName ?? a.person?.fullName ?? '');
-					const bn = String(b.playerInfo?.fullName ?? b.person?.fullName ?? '');
-					return an.localeCompare(bn, undefined, { sensitivity: 'base' });
-				});
-				players.value = sorted;
-				emit('updatePlayers', sorted);
-				emit(
-					'liveMessage',
-					`Showing ${sorted.length} ${sorted.length === 1 ? 'card' : 'cards'} for ${props.team.name}.`
-				);
-			});
-		})
-		.catch(() => {
-			players.value = [];
-			emit('updatePlayers', []);
-			emit('liveMessage', `Could not load the sheet for ${props.team.name}.`);
-		})
-		.finally(() => {
-			emit('rosterLoading', false);
-		});
+function onSelect() {
+	emit('select', props.team);
 }
 </script>
 

--- a/src/lib/rosterLoad.test.ts
+++ b/src/lib/rosterLoad.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchEnrichedRoster } from './rosterLoad';
+
+describe('fetchEnrichedRoster', () => {
+	it('returns sorted enriched players', async () => {
+		const get = vi.fn((url: string) => {
+			if (url.includes('roster')) {
+				return Promise.resolve({
+					data: {
+						roster: [
+							{ person: { id: 2, fullName: 'B Player' } },
+							{ person: { id: 1, fullName: 'A Player' } }
+						]
+					}
+				});
+			}
+			if (url === 'people') {
+				return Promise.resolve({
+					data: {
+						people: [
+							{ id: 1, fullName: 'A Player' },
+							{ id: 2, fullName: 'B Player' }
+						]
+					}
+				});
+			}
+			return Promise.reject(new Error(`Unexpected URL: ${url}`));
+		});
+
+		const result = await fetchEnrichedRoster({ get }, 147);
+		expect(result.empty).toBe(false);
+		expect(result.players.map((r) => r.person?.fullName)).toEqual(['A Player', 'B Player']);
+		expect(result.players[0].playerInfo).toMatchObject({ id: 1, fullName: 'A Player' });
+	});
+
+	it('returns empty when roster has no person ids', async () => {
+		const get = vi.fn().mockResolvedValue({ data: { roster: [{ person: {} }] } });
+		const result = await fetchEnrichedRoster({ get }, 111);
+		expect(result).toEqual({ players: [], empty: true });
+		expect(get).toHaveBeenCalledTimes(1);
+	});
+
+	it('enriches with empty playerInfo when people requests fail', async () => {
+		const get = vi.fn((url: string) => {
+			if (url.includes('roster')) {
+				return Promise.resolve({
+					data: { roster: [{ person: { id: 10, fullName: 'Solo' } }] }
+				});
+			}
+			return Promise.reject(new Error('people down'));
+		});
+
+		const result = await fetchEnrichedRoster({ get }, 111);
+		expect(result.empty).toBe(false);
+		expect(result.players).toHaveLength(1);
+		expect(result.players[0].playerInfo).toEqual({});
+	});
+
+	it('invokes onRosterLoaded before people enrichment', async () => {
+		const order: string[] = [];
+		const get = vi.fn((url: string) => {
+			if (url.includes('roster')) {
+				order.push('roster');
+				return Promise.resolve({
+					data: { roster: [{ person: { id: 1, fullName: 'A' } }] }
+				});
+			}
+			order.push('people');
+			return Promise.resolve({ data: { people: [{ id: 1, fullName: 'A' }] } });
+		});
+
+		await fetchEnrichedRoster({ get }, 1, {
+			onRosterLoaded: () => {
+				order.push('hook');
+			}
+		});
+		expect(order).toEqual(['roster', 'hook', 'people']);
+	});
+
+	it('rejects when the roster request fails', async () => {
+		const get = vi.fn().mockRejectedValue(new Error('network'));
+		await expect(fetchEnrichedRoster({ get }, 147)).rejects.toThrow('network');
+	});
+});

--- a/src/lib/rosterLoad.ts
+++ b/src/lib/rosterLoad.ts
@@ -1,0 +1,67 @@
+import {
+	PEOPLE_BATCH_SIZE,
+	chunkPersonIds,
+	enrichRosterWithPlayerInfo,
+	peopleByIdFromResponses,
+	uniquePersonIds,
+	type RosterRow
+} from './rosterPeople';
+
+/** Minimal HTTP surface used by the MLB proxy client. */
+export type RosterHttp = {
+	/* eslint-disable no-unused-vars -- documents the axios-like get signature */
+	get: (
+		url: string,
+		config?: { params?: Record<string, string> }
+	) => Promise<{ data?: { roster?: RosterRow[]; people?: unknown[] } }>;
+	/* eslint-enable no-unused-vars */
+};
+
+export type FetchEnrichedRosterResult = {
+	players: Array<RosterRow & { playerInfo: Record<string, unknown> }>;
+	/** True when the roster response had no person ids to enrich. */
+	empty: boolean;
+};
+
+function sortRosterByPlayerName<T extends RosterRow & { playerInfo?: { fullName?: string } }>(
+	rows: T[]
+): T[] {
+	return [...rows].sort((a, b) => {
+		const an = String(a.playerInfo?.fullName ?? a.person?.fullName ?? '');
+		const bn = String(b.playerInfo?.fullName ?? b.person?.fullName ?? '');
+		return an.localeCompare(bn, undefined, { sensitivity: 'base' });
+	});
+}
+
+async function fetchPeopleByIds(http: RosterHttp, personIds: number[]) {
+	const unique = uniquePersonIds(personIds);
+	const chunks = chunkPersonIds(unique, PEOPLE_BATCH_SIZE);
+	return Promise.all(
+		chunks.map((chunk) => http.get('people', { params: { personIds: chunk.join(',') } }))
+	)
+		.then((responses) => peopleByIdFromResponses(responses))
+		.catch(() => ({} as Record<number, never>));
+}
+
+/**
+ * Load a club roster and batch-enrich with `/people` (same path as the checklist chips).
+ * Rejects when the roster request fails; people failures degrade to empty `playerInfo`.
+ *
+ * @param opts.onRosterLoaded — called after a non-empty roster sheet arrives (before people batch)
+ */
+export async function fetchEnrichedRoster(
+	http: RosterHttp,
+	teamId: number | string,
+	opts: { onRosterLoaded?: () => void } = {}
+): Promise<FetchEnrichedRosterResult> {
+	const response = await http.get(`teams/${teamId}/roster`);
+	const data = response.data?.roster || [];
+	const ids = data.map((r) => r.person?.id).filter(Boolean) as number[];
+	if (!ids.length) {
+		return { players: [], empty: true };
+	}
+	opts.onRosterLoaded?.();
+	const byId = await fetchPeopleByIds(http, ids);
+	const enriched = enrichRosterWithPlayerInfo(data, byId);
+	return { players: sortRosterByPlayerName(enriched), empty: false };
+}

--- a/src/lib/teamUrlState.test.ts
+++ b/src/lib/teamUrlState.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	TEAM_QUERY_PARAM,
+	applyTeamCodeToUrl,
+	findTeamByTeamCode,
+	normalizeTeamCode,
+	readTeamCodeFromLocation,
+	readTeamCodeFromSearch,
+	writeTeamCodeToHistory
+} from './teamUrlState';
+
+describe('normalizeTeamCode', () => {
+	it('trims and lowercases', () => {
+		expect(normalizeTeamCode('  NYY ')).toBe('nyy');
+	});
+
+	it('returns empty string for nullish', () => {
+		expect(normalizeTeamCode(null)).toBe('');
+		expect(normalizeTeamCode(undefined)).toBe('');
+	});
+});
+
+describe('readTeamCodeFromSearch', () => {
+	it(`reads ${TEAM_QUERY_PARAM} with or without leading ?`, () => {
+		expect(readTeamCodeFromSearch('?team=bos')).toBe('bos');
+		expect(readTeamCodeFromSearch('team=BOS&x=1')).toBe('bos');
+	});
+
+	it('returns null when missing or blank', () => {
+		expect(readTeamCodeFromSearch('')).toBeNull();
+		expect(readTeamCodeFromSearch('?foo=1')).toBeNull();
+		expect(readTeamCodeFromSearch('?team=')).toBeNull();
+		expect(readTeamCodeFromSearch('?team=%20')).toBeNull();
+	});
+});
+
+describe('readTeamCodeFromLocation', () => {
+	it('reads from a location-like search', () => {
+		expect(readTeamCodeFromLocation({ search: '?team=nyy' })).toBe('nyy');
+	});
+});
+
+describe('applyTeamCodeToUrl', () => {
+	it('sets the team param', () => {
+		const url = applyTeamCodeToUrl(new URL('https://example.com/app/'), 'NYY');
+		expect(url.searchParams.get('team')).toBe('nyy');
+	});
+
+	it('removes the team param when cleared', () => {
+		const url = applyTeamCodeToUrl(new URL('https://example.com/app/?team=bos&x=1'), null);
+		expect(url.searchParams.has('team')).toBe(false);
+		expect(url.searchParams.get('x')).toBe('1');
+	});
+
+	it('preserves pathname under a Pages subpath', () => {
+		const url = applyTeamCodeToUrl(
+			new URL('https://user.github.io/baseball-collection/?team=old'),
+			'lad'
+		);
+		expect(url.pathname).toBe('/baseball-collection/');
+		expect(url.searchParams.get('team')).toBe('lad');
+	});
+});
+
+describe('writeTeamCodeToHistory', () => {
+	it('pushState when the query changes', () => {
+		const pushState = vi.fn();
+		const replaceState = vi.fn();
+		writeTeamCodeToHistory(
+			'bos',
+			'push',
+			{ pushState, replaceState, state: { a: 1 } },
+			{ href: 'https://example.com/' }
+		);
+		expect(pushState).toHaveBeenCalledWith({ a: 1 }, '', '/?team=bos');
+		expect(replaceState).not.toHaveBeenCalled();
+	});
+
+	it('replaceState when mode is replace', () => {
+		const pushState = vi.fn();
+		const replaceState = vi.fn();
+		writeTeamCodeToHistory(
+			null,
+			'replace',
+			{ pushState, replaceState, state: null },
+			{ href: 'https://example.com/?team=bos' }
+		);
+		expect(replaceState).toHaveBeenCalledWith(null, '', '/');
+		expect(pushState).not.toHaveBeenCalled();
+	});
+
+	it('no-ops when href would be unchanged', () => {
+		const pushState = vi.fn();
+		const replaceState = vi.fn();
+		writeTeamCodeToHistory(
+			'nyy',
+			'push',
+			{ pushState, replaceState, state: null },
+			{ href: 'https://example.com/?team=nyy' }
+		);
+		expect(pushState).not.toHaveBeenCalled();
+		expect(replaceState).not.toHaveBeenCalled();
+	});
+});
+
+describe('findTeamByTeamCode', () => {
+	const teams = [
+		{ id: 147, name: 'Yankees', teamCode: 'NYY' },
+		{ id: 111, name: 'Red Sox', teamCode: 'BOS' }
+	];
+
+	it('matches case-insensitively', () => {
+		expect(findTeamByTeamCode(teams, 'nyy')?.id).toBe(147);
+		expect(findTeamByTeamCode(teams, 'BOS')?.name).toBe('Red Sox');
+	});
+
+	it('returns undefined for unknown or empty codes', () => {
+		expect(findTeamByTeamCode(teams, 'xyz')).toBeUndefined();
+		expect(findTeamByTeamCode(teams, '')).toBeUndefined();
+		expect(findTeamByTeamCode(null, 'nyy')).toBeUndefined();
+	});
+});

--- a/src/lib/teamUrlState.ts
+++ b/src/lib/teamUrlState.ts
@@ -1,0 +1,80 @@
+/** Query key for shareable club deep links (`?team=nyy`). */
+export const TEAM_QUERY_PARAM = 'team';
+
+export type HistoryWriteMode = 'push' | 'replace';
+
+export type TeamWithCode = {
+	teamCode?: string | null;
+} & Record<string, unknown>;
+
+/** Normalize MLB teamCode for URL + matching (trim, lower-case). */
+export function normalizeTeamCode(code: string | null | undefined): string {
+	return String(code ?? '')
+		.trim()
+		.toLowerCase();
+}
+
+/** Read `team` from a query string (`?team=bos` or `team=bos`). */
+export function readTeamCodeFromSearch(search: string): string | null {
+	const raw = search.startsWith('?') ? search.slice(1) : search;
+	const params = new URLSearchParams(raw);
+	const normalized = normalizeTeamCode(params.get(TEAM_QUERY_PARAM));
+	return normalized || null;
+}
+
+export function readTeamCodeFromLocation(
+	loc: Pick<Location, 'search'> = typeof location !== 'undefined' ? location : { search: '' }
+): string | null {
+	return readTeamCodeFromSearch(loc.search || '');
+}
+
+/** Set or remove `team` on a URL copy (mutates a clone conceptually via new URL). */
+export function applyTeamCodeToUrl(url: URL, teamCode: string | null | undefined): URL {
+	const next = new URL(url.href);
+	const code = normalizeTeamCode(teamCode);
+	if (code) {
+		next.searchParams.set(TEAM_QUERY_PARAM, code);
+	} else {
+		next.searchParams.delete(TEAM_QUERY_PARAM);
+	}
+	return next;
+}
+
+function pathSearchHash(url: URL): string {
+	return `${url.pathname}${url.search}${url.hash}`;
+}
+
+/**
+ * Sync `?team=` with History. No-ops when the resolved href is unchanged
+ * (avoids cluttering the stack on hydrate / re-select).
+ */
+export function writeTeamCodeToHistory(
+	teamCode: string | null | undefined,
+	mode: HistoryWriteMode,
+	historyApi: Pick<History, 'pushState' | 'replaceState' | 'state'> = history,
+	loc: Pick<Location, 'href'> = location
+): void {
+	const current = new URL(loc.href);
+	const next = applyTeamCodeToUrl(current, teamCode);
+	if (next.href === current.href) {
+		return;
+	}
+	const relative = pathSearchHash(next);
+	if (mode === 'push') {
+		historyApi.pushState(historyApi.state, '', relative);
+	} else {
+		historyApi.replaceState(historyApi.state, '', relative);
+	}
+}
+
+/** Find a club whose normalized teamCode matches (e.g. `NYY` ↔ `nyy`). */
+export function findTeamByTeamCode<T extends TeamWithCode>(
+	teams: T[] | null | undefined,
+	code: string | null | undefined
+): T | undefined {
+	const normalized = normalizeTeamCode(code);
+	if (!normalized) {
+		return undefined;
+	}
+	return (teams || []).find((t) => normalizeTeamCode(t.teamCode) === normalized);
+}


### PR DESCRIPTION
## Summary
- Sync the selected club to `?team=<teamCode>` (e.g. `?team=bos`) via the History API — no Vue Router, still a static SPA.
- Hydrate from the query on boot and on `popstate` so refresh, share links, and back/forward work.
- Hoist roster fetch/enrich into `src/lib/rosterLoad.ts` and make checklist chips emit `select`, so deep links work even when a team chip is filtered out of the DOM.

## How to verify
- `npm run lint && npm run test:coverage && npm run build`
- Open `/?team=nyy` (or Pages `?team=nyy`) → Yankees sheet loads after teams resolve
- Pick another club → URL updates; browser Back returns to the previous club
- Unknown `?team=xyz` → live message + query cleared
- Invalid / empty codes are ignored cleanly


Made with [Cursor](https://cursor.com)