### PR TITLE
Add local album favorites and real completeness

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -193,7 +193,7 @@
 										</h2>
 										<p class="album__results-completeness">
 											<span class="album__results-completeness-count">
-												{{ players.length }} {{ players.length === 1 ? 'card' : 'cards' }}
+												{{ rosterAlbumCountLabel }}
 											</span>
 											<span class="album__results-completeness-track" aria-hidden="true">
 												<span
@@ -247,6 +247,8 @@
 											:theme="theme"
 											:teamName="teamName"
 											:manyPlayers="players.length > 30"
+											:collected="isPlayerCollected(player.person?.id)"
+											@toggle-collect="onToggleCollect"
 										/>
 									</div>
 								</div>
@@ -293,6 +295,14 @@ import http from './http-common';
 import { filterMajorLeagueBaseballTeams } from './lib/filterMlbTeams';
 import { fetchEnrichedRoster } from './lib/rosterLoad';
 import {
+	countCollectedOnRoster,
+	isCollected,
+	readAlbumStore,
+	rosterCompletenessFillPercent as albumCompletenessFillPercent,
+	toggleCollected,
+	writeAlbumStore
+} from './lib/albumCollection';
+import {
 	buildTeamPickerSections,
 	filterTeamPickerSections
 } from './lib/teamPickerSections';
@@ -315,6 +325,8 @@ const teamsLoading = ref(true);
 const teamsError = ref('');
 const liveRegionText = ref('');
 const rosterLoading = ref(false);
+/** Client-only album (localStorage); no backend. */
+const albumStore = ref(readAlbumStore(typeof localStorage !== 'undefined' ? localStorage : null));
 /** 'idle' | 'pulling' | 'faces' — while a roster request is in flight */
 const rosterLoadStage = ref('idle');
 const resultsSection = ref(null);
@@ -389,13 +401,26 @@ const teamsSectionsLayoutClass = computed(() => {
 });
 
 /** Full “album page” at 40 cards; bar is a collecting metaphor, not league totals. */
-const rosterCompletenessFillPercent = computed(() => {
-	const n = players.value.length;
-	if (n <= 0) {
-		return '0%';
+const rosterOwnedCount = computed(() =>
+	countCollectedOnRoster(
+		albumStore.value,
+		players.value.map((row) => row?.person?.id)
+	)
+);
+
+const rosterAlbumCountLabel = computed(() => {
+	const total = players.value.length;
+	if (total <= 0) {
+		return '0 cards';
 	}
-	return `${Math.min(100, (n / 40) * 100)}%`;
+	const owned = rosterOwnedCount.value;
+	const cardWord = total === 1 ? 'card' : 'cards';
+	return `${owned} of ${total} ${cardWord} in your album`;
 });
+
+const rosterCompletenessFillPercent = computed(() =>
+	albumCompletenessFillPercent(rosterOwnedCount.value, players.value.length)
+);
 
 const rosterLoadingHeadline = computed(() => {
 	if (rosterLoadStage.value === 'faces') {
@@ -799,6 +824,26 @@ watch(
 
 function setLiveMessage(message) {
 	liveRegionText.value = message;
+}
+
+function isPlayerCollected(personId) {
+	return isCollected(albumStore.value, personId);
+}
+
+function onToggleCollect(personId) {
+	if (personId == null) {
+		return;
+	}
+	const player = players.value.find((row) => row?.person?.id === personId);
+	const name = player?.person?.fullName || player?.playerInfo?.fullName || 'Player';
+	const result = toggleCollected(albumStore.value, personId, {
+		teamId: selectedTeamId.value
+	});
+	albumStore.value = result.store;
+	writeAlbumStore(result.store, typeof localStorage !== 'undefined' ? localStorage : null);
+	setLiveMessage(
+		result.collected ? `Added ${name} to your album.` : `Removed ${name} from your album.`
+	);
 }
 
 function setRosterLoadStage(stage) {

--- a/src/components/BaseballCard.test.ts
+++ b/src/components/BaseballCard.test.ts
@@ -35,7 +35,7 @@ describe('BaseballCard', () => {
 			props: { player, teamName: 'Club', theme: 'bos' },
 			global: { stubs: { CardFront: true, CardBack: true, CardFoilGl: true } }
 		});
-		const flip = wrapper.find('[role="button"]');
+		const flip = wrapper.find('.card__container');
 		expect(flip.attributes('aria-label')).toContain('Test Hitter');
 		expect(flip.attributes('aria-pressed')).toBe('false');
 	});
@@ -45,7 +45,7 @@ describe('BaseballCard', () => {
 			props: { player, teamName: 'Club' },
 			global: { stubs: { CardFront: true, CardBack: true, CardFoilGl: true } }
 		});
-		const flip = wrapper.find('[role="button"]');
+		const flip = wrapper.find('.card__container');
 		await flip.trigger('click');
 		expect(flip.attributes('aria-pressed')).toBe('true');
 		expect(flip.classes()).toContain('card__container--flipped');
@@ -58,7 +58,7 @@ describe('BaseballCard', () => {
 			props: { player, teamName: 'Club' },
 			global: { stubs: { CardFront: true, CardBack: true, CardFoilGl: true } }
 		});
-		const flip = wrapper.find('[role="button"]');
+		const flip = wrapper.find('.card__container');
 		await flip.trigger('focus');
 		await flip.trigger('keydown', { key: 'Enter' });
 		expect(flip.attributes('aria-pressed')).toBe('true');
@@ -69,9 +69,33 @@ describe('BaseballCard', () => {
 			props: { player, teamName: 'Club' },
 			global: { stubs: { CardFront: true, CardBack: true, CardFoilGl: true } }
 		});
-		const flip = wrapper.find('[role="button"]');
+		const flip = wrapper.find('.card__container');
 		await flip.trigger('keydown', { key: ' ' });
 		expect(flip.attributes('aria-pressed')).toBe('true');
+	});
+
+	it('exposes a collect control outside the flip target', async () => {
+		const wrapper = mount(BaseballCard, {
+			props: { player, teamName: 'Club', collected: false },
+			global: { stubs: { CardFront: true, CardBack: true, CardFoilGl: true } }
+		});
+		const collect = wrapper.find('.card__collect');
+		expect(collect.attributes('aria-label')).toBe('Add Test Hitter to your album');
+		expect(collect.attributes('aria-pressed')).toBe('false');
+		await collect.trigger('click');
+		expect(wrapper.emitted('toggle-collect')?.[0]).toEqual([501]);
+		expect(wrapper.find('.card__container').attributes('aria-pressed')).toBe('false');
+	});
+
+	it('labels collect as remove when the card is already in the album', () => {
+		const wrapper = mount(BaseballCard, {
+			props: { player, teamName: 'Club', collected: true },
+			global: { stubs: { CardFront: true, CardBack: true, CardFoilGl: true } }
+		});
+		expect(wrapper.find('.card__collect').attributes('aria-label')).toBe(
+			'Remove Test Hitter from your album'
+		);
+		expect(wrapper.find('.card__shell').classes()).toContain('card__shell--collected');
 	});
 
 	it('claims the foil target when the scene receives pointer enter', async () => {
@@ -130,7 +154,7 @@ describe('BaseballCard', () => {
 			attachTo: document.body,
 			global: { stubs: { CardFront: true, CardBack: true, CardFoilGl: true } }
 		});
-		const flip = wrapper.find('[role="button"]').element;
+		const flip = wrapper.find('.card__container').element;
 		flip.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
 		expect(spy).toHaveBeenCalled();
 		spy.mockRestore();
@@ -142,7 +166,7 @@ describe('BaseballCard', () => {
 			props: { player, teamName: 'Club' },
 			global: { stubs: { CardFront: true, CardBack: true, CardFoilGl: true } }
 		});
-		const flip = wrapper.find('[role="button"]');
+		const flip = wrapper.find('.card__container');
 		await flip.trigger('keydown', { key: 'Tab' });
 		expect(flip.attributes('aria-pressed')).toBe('false');
 	});

--- a/src/components/BaseballCard.vue
+++ b/src/components/BaseballCard.vue
@@ -1,49 +1,66 @@
 <template>
 	<div class="card__defer">
 		<div
-			ref="sceneRef"
-			class="card__scene"
-			:class="{ 'card__scene--many': manyPlayers }"
-			:data-theme="theme || undefined"
-			:style="tiltStyle"
-			@pointerenter="onScenePointerEnter"
-			@pointermove="onPointerMove"
-			@pointerleave="onScenePointerLeave"
-			@pointerdown="onPointerDown"
-			@focusin.capture="onSceneFocusIn"
-			@focusout.capture="onSceneFocusOut"
+			class="card__shell"
+			:class="{ 'card__shell--collected': collected }"
 		>
-			<div ref="tiltRef" class="card__tilt">
-				<div
-					class="card__container"
-					role="button"
-					tabindex="0"
-					:aria-pressed="flipped"
-					:aria-label="flipAriaLabel"
-					@click="flipCard"
-					@keydown="onFlipKeydown"
-					v-bind:class="{ 'card__container--flipped': flipped }"
-				>
-					<CardFront
-						:player="player"
-						:teamName="teamName"
-						:positionName="primaryPositionName"
-						:manyPlayers="manyPlayers"
-					/>
-					<CardBack
-						v-if="flipped || hasLoadedBack"
-						:player="player"
-						:playerInfo="player.playerInfo"
-						:teamName="teamName"
-						:manyPlayers="manyPlayers"
+			<button
+				type="button"
+				class="card__collect"
+				:aria-pressed="collected ? 'true' : 'false'"
+				:aria-label="collectAriaLabel"
+				@click="onCollectClick"
+			>
+				<span class="card__collect-mark" aria-hidden="true">{{ collected ? 'IN' : '+' }}</span>
+				<span class="card__collect-label" aria-hidden="true">{{
+					collected ? 'Album' : 'Collect'
+				}}</span>
+			</button>
+			<div
+				ref="sceneRef"
+				class="card__scene"
+				:class="{ 'card__scene--many': manyPlayers }"
+				:data-theme="theme || undefined"
+				:style="tiltStyle"
+				@pointerenter="onScenePointerEnter"
+				@pointermove="onPointerMove"
+				@pointerleave="onScenePointerLeave"
+				@pointerdown="onPointerDown"
+				@focusin.capture="onSceneFocusIn"
+				@focusout.capture="onSceneFocusOut"
+			>
+				<div ref="tiltRef" class="card__tilt">
+					<div
+						class="card__container"
+						role="button"
+						tabindex="0"
+						:aria-pressed="flipped"
+						:aria-label="flipAriaLabel"
+						@click="flipCard"
+						@keydown="onFlipKeydown"
+						v-bind:class="{ 'card__container--flipped': flipped }"
+					>
+						<CardFront
+							:player="player"
+							:teamName="teamName"
+							:positionName="primaryPositionName"
+							:manyPlayers="manyPlayers"
+						/>
+						<CardBack
+							v-if="flipped || hasLoadedBack"
+							:player="player"
+							:playerInfo="player.playerInfo"
+							:teamName="teamName"
+							:manyPlayers="manyPlayers"
+						/>
+					</div>
+					<CardFoilGl
+						v-if="isFoilTarget"
+						:container-el="tiltRef"
+						:face-back="flipped"
+						:many-players="manyPlayers"
 					/>
 				</div>
-				<CardFoilGl
-					v-if="isFoilTarget"
-					:container-el="tiltRef"
-					:face-back="flipped"
-					:many-players="manyPlayers"
-				/>
 			</div>
 		</div>
 	</div>
@@ -70,14 +87,24 @@ const props = defineProps({
 	manyPlayers: {
 		type: Boolean,
 		default: false
+	},
+	collected: {
+		type: Boolean,
+		default: false
 	}
 });
+
+const emit = defineEmits(['toggle-collect']);
 
 const sceneRef = ref(null);
 const tiltRef = ref(null);
 
 const primaryPositionName = computed(
 	() => props.player?.playerInfo?.primaryPosition?.name ?? ''
+);
+
+const playerDisplayName = computed(
+	() => props.player?.person?.fullName || 'Player'
 );
 
 const isFoilTarget = computed(() => {
@@ -150,8 +177,12 @@ const flipped = ref(false);
 const hasLoadedBack = ref(false);
 
 const flipAriaLabel = computed(() => {
-	const name = props.player?.person?.fullName || 'Player';
-	return `Baseball card for ${name}. Press Enter or Space to flip between front and back.`;
+	return `Baseball card for ${playerDisplayName.value}. Press Enter or Space to flip between front and back.`;
+});
+
+const collectAriaLabel = computed(() => {
+	const name = playerDisplayName.value;
+	return props.collected ? `Remove ${name} from your album` : `Add ${name} to your album`;
 });
 
 function flipCard() {
@@ -169,6 +200,14 @@ function onFlipKeydown(event) {
 	event.preventDefault();
 	flipCard();
 }
+
+function onCollectClick() {
+	const id = props.player?.person?.id;
+	if (id == null) {
+		return;
+	}
+	emit('toggle-collect', id);
+}
 </script>
 
 <style scoped>
@@ -182,6 +221,68 @@ function onFlipKeydown(event) {
 	content-visibility: visible;
 	max-width: 280px;
 	width: 100%;
+}
+
+.card__shell {
+	position: relative;
+	width: 100%;
+}
+
+.card__collect {
+	align-items: center;
+	background: color-mix(in srgb, var(--color-surface-elevated, #f7f3ea) 88%, var(--color-ui-crimson, #9b1c1c));
+	border: 1px solid color-mix(in srgb, var(--color-text) 28%, transparent);
+	border-radius: 0;
+	box-shadow: 0 1px 0 color-mix(in srgb, var(--color-ink, #1c1917) 12%, transparent);
+	color: var(--color-text);
+	cursor: pointer;
+	display: inline-flex;
+	font-family: var(--font-ui-heading, var(--font-card));
+	font-size: 0.625rem;
+	font-weight: 700;
+	gap: 0.28rem;
+	letter-spacing: 0.08em;
+	line-height: 1;
+	padding: 0.35rem 0.45rem;
+	position: absolute;
+	right: 0.35rem;
+	text-transform: uppercase;
+	top: 0.35rem;
+	z-index: 4;
+}
+
+.card__collect:focus {
+	outline: none;
+}
+
+.card__collect:focus-visible {
+	box-shadow:
+		0 0 0 3px var(--color-focus-ring),
+		0 0 0 5px var(--color-accent);
+}
+
+.card__collect[aria-pressed='true'] {
+	background: color-mix(in srgb, var(--theme-heading, var(--color-ui-crimson)) 18%, var(--color-surface-elevated, #f7f3ea));
+	border-color: var(--theme-heading, var(--color-ui-crimson));
+	color: var(--theme-heading, var(--color-ui-crimson));
+}
+
+.card__collect-mark {
+	font-size: 0.7rem;
+	line-height: 1;
+}
+
+.card__collect-label {
+	max-width: 4.5rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.card__shell--collected .card__scene {
+	box-shadow:
+		var(--shadow-card),
+		inset 0 0 0 2px color-mix(in srgb, var(--theme-heading, var(--color-ui-crimson)) 55%, transparent);
 }
 
 /* Card typography: var(--font-card) — Archivo; see src/styles/tokens.css */
@@ -221,6 +322,11 @@ function onFlipKeydown(event) {
 }
 
 @media (prefers-color-scheme: dark) {
+	.card__collect {
+		background: color-mix(in srgb, var(--color-surface-elevated, #1c1917) 70%, var(--color-ui-crimson, #f87171));
+		border-color: color-mix(in srgb, var(--color-text) 35%, transparent);
+	}
+
 	.card__scene:hover,
 	.card__scene:focus-within:has(.card__container:focus-visible) {
 		box-shadow:

--- a/src/lib/albumCollection.test.ts
+++ b/src/lib/albumCollection.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	ALBUM_STORAGE_KEY,
+	countCollectedOnRoster,
+	createEmptyAlbumStore,
+	isCollected,
+	normalizeAlbumStore,
+	readAlbumStore,
+	rosterCompletenessFillPercent,
+	toggleCollected,
+	writeAlbumStore
+} from './albumCollection';
+
+function memoryStorage(initial: Record<string, string> = {}): Storage {
+	const map = new Map(Object.entries(initial));
+	return {
+		get length() {
+			return map.size;
+		},
+		clear() {
+			map.clear();
+		},
+		getItem(key: string) {
+			return map.has(key) ? map.get(key)! : null;
+		},
+		key() {
+			return null;
+		},
+		removeItem(key: string) {
+			map.delete(key);
+		},
+		setItem(key: string, value: string) {
+			map.set(key, String(value));
+		}
+	};
+}
+
+describe('normalizeAlbumStore', () => {
+	it('returns empty for invalid payloads', () => {
+		expect(normalizeAlbumStore(null)).toEqual(createEmptyAlbumStore());
+		expect(normalizeAlbumStore({ version: 2, collected: {} })).toEqual(createEmptyAlbumStore());
+		expect(normalizeAlbumStore({ version: 1 })).toEqual(createEmptyAlbumStore());
+	});
+
+	it('keeps valid collected entries', () => {
+		const store = normalizeAlbumStore({
+			version: 1,
+			collected: {
+				'12': { personId: 12, teamId: 147, collectedAt: '2020-01-01T00:00:00.000Z' },
+				bad: { personId: 'nope' }
+			}
+		});
+		expect(Object.keys(store.collected)).toEqual(['12']);
+		expect(store.collected['12'].teamId).toBe(147);
+	});
+});
+
+describe('readAlbumStore / writeAlbumStore', () => {
+	it('round-trips through storage', () => {
+		const storage = memoryStorage();
+		const next = toggleCollected(createEmptyAlbumStore(), 99, {
+			teamId: 111,
+			now: new Date('2024-06-01T12:00:00.000Z')
+		}).store;
+		writeAlbumStore(next, storage);
+		expect(storage.getItem(ALBUM_STORAGE_KEY)).toContain('"99"');
+		expect(readAlbumStore(storage).collected['99'].personId).toBe(99);
+	});
+
+	it('returns empty when storage is missing or corrupt', () => {
+		expect(readAlbumStore(null)).toEqual(createEmptyAlbumStore());
+		const storage = memoryStorage({ [ALBUM_STORAGE_KEY]: '{not-json' });
+		expect(readAlbumStore(storage)).toEqual(createEmptyAlbumStore());
+	});
+
+	it('writeAlbumStore no-ops without setItem', () => {
+		expect(() => writeAlbumStore(createEmptyAlbumStore(), null)).not.toThrow();
+	});
+});
+
+describe('toggleCollected / isCollected', () => {
+	it('adds then removes a player', () => {
+		const added = toggleCollected(createEmptyAlbumStore(), 7, { teamId: 147 });
+		expect(added.collected).toBe(true);
+		expect(isCollected(added.store, 7)).toBe(true);
+
+		const removed = toggleCollected(added.store, 7);
+		expect(removed.collected).toBe(false);
+		expect(isCollected(removed.store, 7)).toBe(false);
+	});
+
+	it('treats nullish person ids as not collected', () => {
+		expect(isCollected(createEmptyAlbumStore(), null)).toBe(false);
+		expect(isCollected(null, 1)).toBe(false);
+	});
+});
+
+describe('countCollectedOnRoster', () => {
+	it('counts unique roster ids present in the album', () => {
+		let store = createEmptyAlbumStore();
+		store = toggleCollected(store, 1).store;
+		store = toggleCollected(store, 2).store;
+		store = toggleCollected(store, 99).store;
+		expect(countCollectedOnRoster(store, [1, 2, 2, null, 3])).toBe(2);
+	});
+});
+
+describe('rosterCompletenessFillPercent', () => {
+	it('scales owned/total and clamps', () => {
+		expect(rosterCompletenessFillPercent(0, 26)).toBe('0%');
+		expect(rosterCompletenessFillPercent(13, 26)).toBe('50%');
+		expect(rosterCompletenessFillPercent(26, 26)).toBe('100%');
+		expect(rosterCompletenessFillPercent(40, 20)).toBe('100%');
+	});
+});
+
+describe('readAlbumStore JSON parse errors', () => {
+	it('swallows getItem throws', () => {
+		const storage = {
+			getItem: () => {
+				throw new Error('denied');
+			},
+			setItem: vi.fn(),
+			removeItem: vi.fn()
+		};
+		expect(readAlbumStore(storage)).toEqual(createEmptyAlbumStore());
+	});
+});

--- a/src/lib/albumCollection.ts
+++ b/src/lib/albumCollection.ts
@@ -1,0 +1,159 @@
+/** localStorage key for the client-only album (no backend). */
+export const ALBUM_STORAGE_KEY = 'cartophiles.album.v1';
+
+export type AlbumCollectedEntry = {
+	personId: number;
+	teamId?: number | null;
+	collectedAt: string;
+};
+
+export type AlbumStore = {
+	version: 1;
+	collected: Record<string, AlbumCollectedEntry>;
+};
+
+export type ToggleCollectMeta = {
+	teamId?: number | null;
+	now?: Date;
+};
+
+export type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export function createEmptyAlbumStore(): AlbumStore {
+	return { version: 1, collected: {} };
+}
+
+function personKey(personId: number): string {
+	return String(personId);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Coerce unknown JSON into a v1 album store (invalid shapes → empty). */
+export function normalizeAlbumStore(raw: unknown): AlbumStore {
+	if (!isPlainObject(raw) || raw.version !== 1 || !isPlainObject(raw.collected)) {
+		return createEmptyAlbumStore();
+	}
+	const collected: Record<string, AlbumCollectedEntry> = {};
+	for (const [key, entry] of Object.entries(raw.collected)) {
+		if (!isPlainObject(entry)) {
+			continue;
+		}
+		const personId = Number(entry.personId ?? key);
+		if (!Number.isFinite(personId)) {
+			continue;
+		}
+		collected[personKey(personId)] = {
+			personId,
+			teamId:
+				entry.teamId == null || entry.teamId === ''
+					? null
+					: Number.isFinite(Number(entry.teamId))
+						? Number(entry.teamId)
+						: null,
+			collectedAt:
+				typeof entry.collectedAt === 'string' && entry.collectedAt
+					? entry.collectedAt
+					: new Date(0).toISOString()
+		};
+	}
+	return { version: 1, collected };
+}
+
+export function readAlbumStore(storage: StorageLike | null | undefined): AlbumStore {
+	if (!storage || typeof storage.getItem !== 'function') {
+		return createEmptyAlbumStore();
+	}
+	try {
+		const raw = storage.getItem(ALBUM_STORAGE_KEY);
+		if (!raw) {
+			return createEmptyAlbumStore();
+		}
+		return normalizeAlbumStore(JSON.parse(raw));
+	} catch {
+		return createEmptyAlbumStore();
+	}
+}
+
+export function writeAlbumStore(
+	store: AlbumStore,
+	storage: StorageLike | null | undefined
+): void {
+	if (!storage || typeof storage.setItem !== 'function') {
+		return;
+	}
+	const normalized = normalizeAlbumStore(store);
+	storage.setItem(ALBUM_STORAGE_KEY, JSON.stringify(normalized));
+}
+
+export function isCollected(
+	store: AlbumStore | null | undefined,
+	personId: number | null | undefined
+): boolean {
+	if (personId == null || !Number.isFinite(personId) || !store?.collected) {
+		return false;
+	}
+	return personKey(personId) in store.collected;
+}
+
+/**
+ * Add or remove a person from the album.
+ * Returns a new store object (immutable-friendly for Vue refs).
+ */
+export function toggleCollected(
+	store: AlbumStore | null | undefined,
+	personId: number,
+	meta: ToggleCollectMeta = {}
+): { store: AlbumStore; collected: boolean } {
+	const base = normalizeAlbumStore(store ?? createEmptyAlbumStore());
+	const key = personKey(personId);
+	const nextCollected = { ...base.collected };
+
+	if (key in nextCollected) {
+		delete nextCollected[key];
+		return {
+			store: { version: 1, collected: nextCollected },
+			collected: false
+		};
+	}
+
+	const now = meta.now ?? new Date();
+	nextCollected[key] = {
+		personId,
+		teamId: meta.teamId ?? null,
+		collectedAt: now.toISOString()
+	};
+	return {
+		store: { version: 1, collected: nextCollected },
+		collected: true
+	};
+}
+
+/** How many roster person IDs appear in the album. */
+export function countCollectedOnRoster(
+	store: AlbumStore | null | undefined,
+	personIds: Array<number | null | undefined>
+): number {
+	let n = 0;
+	const seen = new Set<number>();
+	for (const id of personIds) {
+		if (id == null || !Number.isFinite(id) || seen.has(id)) {
+			continue;
+		}
+		seen.add(id);
+		if (isCollected(store, id)) {
+			n += 1;
+		}
+	}
+	return n;
+}
+
+/** Completeness fill width for the roster pennant strip. */
+export function rosterCompletenessFillPercent(owned: number, total: number): string {
+	if (!(total > 0) || !(owned > 0)) {
+		return '0%';
+	}
+	return `${Math.min(100, (owned / total) * 100)}%`;
+}


### PR DESCRIPTION
## Summary
- Client-only album: collect/remove pasteboards via `localStorage` (`cartophiles.album.v1`) — no backend or database.
- Collect control sits **outside** the flip hit target (separate `<button>`, proper `aria-pressed` / labels).
- Roster pennant completeness is now **owned / roster size** (was decorative `n/40`).
- Depends on Phase 1 URL state (#92); this PR targets `feat/url-team-state`.

## How to verify
- Merge or check out after #92; `npm run lint && npm run test:coverage && npm run build`
- Open a club sheet → Collect on a card → label/ring update; refresh → still collected
- Completeness copy shows `k of n … in your album`; fill width tracks owned count
- Collect does not flip the card; flip still works independently
- Live region announces add/remove


Made with [Cursor](https://cursor.com)