### PR TITLE
Polish album filter, club badges, and product docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Per-franchise caps and fields: `--theme-*` in `src/styles/team-themes.css`. **Up
 
 | TAG | WHAT HAPPENS |
 | --- | ------------ |
-| **CLUB CHECKLIST** | MLB teams filtered to `sport.name === 'Major League Baseball'`; AL / NL sections + search |
+| **CLUB CHECKLIST** | MLB teams filtered to `sport.name === 'Major League Baseball'`; AL / NL sections + search; per-club album count badges |
+| **SHAREABLE CLUB** | `?team=<teamCode>` deep links (History API); refresh / share / back-forward restore the sheet |
+| **LOCAL ALBUM** | Collect pasteboards in the browser (`localStorage`); completeness is owned vs roster; Full sheet / In album filter |
 | **ROSTER GRID** | One **1959-style** card per active player; team crest + theme on the front |
 | **FLIP** | Click / keyboard flip; back pulls bat/ball stats lines from batched people payload |
 | **TILT + FOIL** | Pointer tilt on the scene; optional WebGL foil path on a single “chase” card target |
@@ -86,6 +88,8 @@ Per-franchise caps and fields: `--theme-*` in `src/styles/team-themes.css`. **Up
 | **BATCH PEOPLE** | Up to **50** IDs per `GET /people?personIds=…` (proxy also accepts `ids`) |
 | **CACHE** | Short-lived Axios cache adapter on the client |
 | **DARK NIGHT GAME** | `prefers-color-scheme: dark` retints `:root` in `tokens.css` (warmer cards under “lights”) |
+
+> **Product note:** Club URLs are shareable; your album stays on-device only (no account / database). Sharing `?team=bos` opens the Red Sox sheet — not someone else’s collection.
 
 ```
 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓

--- a/src/App.vue
+++ b/src/App.vue
@@ -125,6 +125,7 @@
 														:key="team.id"
 														:team="team"
 														:selected="selectedTeamId === team.id"
+														:album-count="albumCountByTeamId[team.id] || 0"
 														@select="onTeamSelect"
 													/>
 												</div>
@@ -201,10 +202,32 @@
 													:style="{ width: rosterCompletenessFillPercent }"
 												></span>
 											</span>
-									</p>
-								</div>
+										</p>
+										<div
+											class="album__roster-filter"
+											role="group"
+											aria-label="Roster view"
+										>
+											<button
+												type="button"
+												class="album__roster-filter-btn"
+												:aria-pressed="rosterAlbumFilter === 'all' ? 'true' : 'false'"
+												@click="setRosterAlbumFilter('all')"
+											>
+												Full sheet
+											</button>
+											<button
+												type="button"
+												class="album__roster-filter-btn"
+												:aria-pressed="rosterAlbumFilter === 'album' ? 'true' : 'false'"
+												@click="setRosterAlbumFilter('album')"
+											>
+												In album
+											</button>
+										</div>
+									</div>
 								<div
-									v-if="players.length"
+									v-if="displayedPlayers.length"
 									class="album__results-cards-region"
 									:class="{
 										'album__results-cards-region--rm-reveal': dealPhase === 'static'
@@ -222,7 +245,7 @@
 									></div>
 									<Transition name="album-pack-out">
 										<div
-											v-if="dealPhase === 'opening'"
+											v-if="dealPhase === 'opening' && rosterAlbumFilter === 'all'"
 											class="album__pack-stage album__pack-stage--deal-act1"
 										>
 											<AlbumPackLottie
@@ -234,7 +257,7 @@
 										</div>
 									</Transition>
 									<div
-										v-for="player in players"
+										v-for="player in displayedPlayers"
 										:key="player.person.id"
 										class="album__card-deal"
 										:class="[
@@ -253,7 +276,20 @@
 									</div>
 								</div>
 								<p
-									v-if="!players.length"
+									v-if="showAlbumFilterEmpty"
+									class="album__results-empty album__results-empty--filter"
+								>
+									No pasteboards in your album for the {{ teamName }} yet.
+									<button
+										type="button"
+										class="album__results-empty-action"
+										@click="setRosterAlbumFilter('all')"
+									>
+										Show full sheet
+									</button>
+								</p>
+								<p
+									v-else-if="!players.length"
 									class="album__results-empty"
 								>
 									No pasteboards on file for the {{ teamName }}.
@@ -295,7 +331,9 @@ import http from './http-common';
 import { filterMajorLeagueBaseballTeams } from './lib/filterMlbTeams';
 import { fetchEnrichedRoster } from './lib/rosterLoad';
 import {
+	countCollectedByTeamId,
 	countCollectedOnRoster,
+	filterRosterPlayersByAlbum,
 	isCollected,
 	readAlbumStore,
 	rosterCompletenessFillPercent as albumCompletenessFillPercent,
@@ -327,6 +365,8 @@ const liveRegionText = ref('');
 const rosterLoading = ref(false);
 /** Client-only album (localStorage); no backend. */
 const albumStore = ref(readAlbumStore(typeof localStorage !== 'undefined' ? localStorage : null));
+/** 'all' | 'album' — which pasteboards to show for the open club. */
+const rosterAlbumFilter = ref('all');
 /** 'idle' | 'pulling' | 'faces' — while a roster request is in flight */
 const rosterLoadStage = ref('idle');
 const resultsSection = ref(null);
@@ -400,7 +440,23 @@ const teamsSectionsLayoutClass = computed(() => {
 	return 'teams__sections--multi';
 });
 
-/** Full “album page” at 40 cards; bar is a collecting metaphor, not league totals. */
+/** Owned counts per club from collect-time teamId tags. */
+const albumCountByTeamId = computed(() => countCollectedByTeamId(albumStore.value));
+
+/** Roster rows after Full sheet / In album filter. */
+const displayedPlayers = computed(() =>
+	filterRosterPlayersByAlbum(players.value, albumStore.value, rosterAlbumFilter.value)
+);
+
+const showAlbumFilterEmpty = computed(
+	() =>
+		!rosterLoading.value &&
+		players.value.length > 0 &&
+		rosterAlbumFilter.value === 'album' &&
+		displayedPlayers.value.length === 0
+);
+
+/** Completeness uses the full club sheet; filter only changes which cards render. */
 const rosterOwnedCount = computed(() =>
 	countCollectedOnRoster(
 		albumStore.value,
@@ -830,6 +886,26 @@ function isPlayerCollected(personId) {
 	return isCollected(albumStore.value, personId);
 }
 
+function setRosterAlbumFilter(next) {
+	if (next !== 'all' && next !== 'album') {
+		return;
+	}
+	if (rosterAlbumFilter.value === next) {
+		return;
+	}
+	rosterAlbumFilter.value = next;
+	if (next === 'album') {
+		const n = displayedPlayers.value.length;
+		setLiveMessage(
+			n > 0
+				? `Showing ${n} ${n === 1 ? 'card' : 'cards'} in your album for the ${teamName.value}.`
+				: `No pasteboards in your album for the ${teamName.value} yet.`
+		);
+	} else {
+		setLiveMessage(`Showing the full sheet for the ${teamName.value}.`);
+	}
+}
+
 function onToggleCollect(personId) {
 	if (personId == null) {
 		return;
@@ -861,6 +937,7 @@ function applySelectedTeam(team) {
 	selectedTeamId.value = team.id;
 	theme.value = team.teamCode?.toLowerCase() || '';
 	teamName.value = team.name;
+	rosterAlbumFilter.value = 'all';
 }
 
 function clearSelectedTeam() {
@@ -868,6 +945,7 @@ function clearSelectedTeam() {
 	theme.value = '';
 	teamName.value = '';
 	players.value = [];
+	rosterAlbumFilter.value = 'all';
 }
 
 /**
@@ -1528,6 +1606,37 @@ body {
 	margin: 0;
 	text-align: center;
 	width: 100%;
+}
+
+.album__results-empty--filter {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-3);
+	padding-block: var(--space-4);
+}
+
+.album__results-empty-action {
+	background: color-mix(in srgb, var(--color-surface-elevated, #f7f3ea) 88%, var(--color-ui-crimson));
+	border: 2px solid var(--color-ui-ink, var(--color-text));
+	color: var(--color-text);
+	cursor: pointer;
+	font-family: var(--font-ui-heading);
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.1em;
+	padding: 0.45rem 0.85rem;
+	text-transform: uppercase;
+}
+
+.album__results-empty-action:focus {
+	outline: none;
+}
+
+.album__results-empty-action:focus-visible {
+	box-shadow:
+		0 0 0 3px var(--color-focus-ring),
+		0 0 0 5px var(--color-accent);
 }
 
 .teams__nav {
@@ -2784,6 +2893,55 @@ h2 {
 	margin: 0;
 	max-width: min(26rem, 100%);
 	width: 100%;
+}
+
+.album__roster-filter {
+	display: inline-flex;
+	gap: 0;
+	margin: 0.15rem 0 0;
+	max-width: 100%;
+}
+
+.album__roster-filter-btn {
+	background: color-mix(in srgb, var(--color-surface-elevated, #f7f3ea) 92%, transparent);
+	border: 1px solid color-mix(in srgb, var(--color-text) 28%, transparent);
+	color: var(--color-text-muted);
+	cursor: pointer;
+	font-family: var(--font-ui-heading);
+	font-size: 0.6875rem;
+	font-weight: 600;
+	letter-spacing: 0.1em;
+	line-height: 1;
+	padding: 0.4rem 0.7rem;
+	text-transform: uppercase;
+}
+
+.album__roster-filter-btn + .album__roster-filter-btn {
+	border-left-width: 0;
+}
+
+.album__roster-filter-btn:focus {
+	outline: none;
+}
+
+.album__roster-filter-btn:focus-visible {
+	box-shadow:
+		0 0 0 3px var(--color-focus-ring),
+		0 0 0 5px var(--color-accent);
+	position: relative;
+	z-index: 1;
+}
+
+.album__roster-filter-btn[aria-pressed='true'] {
+	background: color-mix(in srgb, var(--theme-heading, var(--color-ui-crimson)) 14%, var(--color-surface-elevated, #f7f3ea));
+	border-color: var(--theme-heading, var(--color-ui-crimson));
+	color: var(--theme-heading, var(--color-ui-crimson));
+}
+
+@media (prefers-color-scheme: dark) {
+	.album__roster-filter-btn {
+		background: color-mix(in srgb, var(--color-surface-elevated, #1c1917) 80%, transparent);
+	}
 }
 
 .album__results-completeness-count {

--- a/src/components/Team.test.ts
+++ b/src/components/Team.test.ts
@@ -29,4 +29,15 @@ describe('Team', () => {
 		await wrapper.find('button').trigger('click');
 		expect(wrapper.emitted('select')?.[0]).toEqual([yankees]);
 	});
+
+	it('shows an album count badge when albumCount is positive', () => {
+		const wrapper = mount(Team, { props: { team: yankees, albumCount: 3 } });
+		expect(wrapper.find('.team__album-count').text()).toBe('3');
+		expect(wrapper.text()).toContain('3 in your album');
+	});
+
+	it('hides the album count badge when albumCount is zero', () => {
+		const wrapper = mount(Team, { props: { team: yankees, albumCount: 0 } });
+		expect(wrapper.find('.team__album-count').exists()).toBe(false);
+	});
 });

--- a/src/components/Team.vue
+++ b/src/components/Team.vue
@@ -10,6 +10,19 @@
 		<span class="team__inner">
 			<span class="team__logo" aria-hidden="true"></span>
 			<span class="team__name">{{ team.name }}</span>
+			<span
+				v-if="albumCount > 0"
+				class="visually-hidden"
+			>
+				, {{ albumCount }} in your album
+			</span>
+		</span>
+		<span
+			v-if="albumCount > 0"
+			class="team__album-count"
+			aria-hidden="true"
+		>
+			{{ albumCount }}
 		</span>
 	</button>
 </template>
@@ -24,6 +37,10 @@ const props = defineProps({
 	selected: {
 		type: Boolean,
 		default: false
+	},
+	albumCount: {
+		type: Number,
+		default: 0
 	}
 });
 
@@ -266,5 +283,35 @@ function onSelect() {
 	.team__logo::before {
 		transform: translate(-50%, -50%) scale(calc(26 / 30));
 	}
+}
+
+.team__album-count {
+	background: color-mix(in srgb, var(--theme-logo-border, var(--color-accent)) 18%, var(--color-surface-elevated, #f7f3ea));
+	border: 1px solid color-mix(in srgb, var(--theme-logo-border, var(--color-accent)) 55%, transparent);
+	bottom: 0.35rem;
+	color: var(--color-text);
+	font-family: var(--font-ui-heading, var(--font-card));
+	font-size: 0.625rem;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	line-height: 1;
+	min-width: 1.15rem;
+	padding: 0.2rem 0.28rem;
+	position: absolute;
+	right: 0.35rem;
+	text-align: center;
+	z-index: 3;
+}
+
+.visually-hidden {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
 }
 </style>

--- a/src/lib/albumCollection.test.ts
+++ b/src/lib/albumCollection.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
 	ALBUM_STORAGE_KEY,
+	countCollectedByTeamId,
+	countCollectedForTeam,
 	countCollectedOnRoster,
 	createEmptyAlbumStore,
+	filterRosterPlayersByAlbum,
 	isCollected,
 	normalizeAlbumStore,
 	readAlbumStore,
@@ -102,6 +105,49 @@ describe('countCollectedOnRoster', () => {
 		store = toggleCollected(store, 2).store;
 		store = toggleCollected(store, 99).store;
 		expect(countCollectedOnRoster(store, [1, 2, 2, null, 3])).toBe(2);
+	});
+});
+
+describe('countCollectedForTeam / countCollectedByTeamId', () => {
+	it('tallies collect-time team ids', () => {
+		let store = createEmptyAlbumStore();
+		store = toggleCollected(store, 1, { teamId: 147 }).store;
+		store = toggleCollected(store, 2, { teamId: 147 }).store;
+		store = toggleCollected(store, 3, { teamId: 111 }).store;
+		store = toggleCollected(store, 4).store;
+		expect(countCollectedByTeamId(store)).toEqual({ 147: 2, 111: 1 });
+		expect(countCollectedForTeam(store, 147)).toBe(2);
+		expect(countCollectedForTeam(store, 111)).toBe(1);
+		expect(countCollectedForTeam(store, 999)).toBe(0);
+		expect(countCollectedForTeam(store, null)).toBe(0);
+	});
+});
+
+describe('filterRosterPlayersByAlbum', () => {
+	const roster = [
+		{ person: { id: 1, fullName: 'A' } },
+		{ person: { id: 2, fullName: 'B' } },
+		{ person: { id: 3, fullName: 'C' } }
+	];
+
+	it('returns the full list for all / default', () => {
+		const store = toggleCollected(createEmptyAlbumStore(), 1).store;
+		expect(filterRosterPlayersByAlbum(roster, store, 'all')).toEqual(roster);
+		expect(filterRosterPlayersByAlbum(roster, store)).toEqual(roster);
+	});
+
+	it('keeps only collected players for album filter', () => {
+		let store = createEmptyAlbumStore();
+		store = toggleCollected(store, 2).store;
+		store = toggleCollected(store, 3).store;
+		expect(filterRosterPlayersByAlbum(roster, store, 'album').map((r) => r.person.id)).toEqual([
+			2, 3
+		]);
+	});
+
+	it('returns empty when nothing collected', () => {
+		expect(filterRosterPlayersByAlbum(roster, createEmptyAlbumStore(), 'album')).toEqual([]);
+		expect(filterRosterPlayersByAlbum(null, createEmptyAlbumStore(), 'album')).toEqual([]);
 	});
 });
 

--- a/src/lib/albumCollection.ts
+++ b/src/lib/albumCollection.ts
@@ -150,6 +150,50 @@ export function countCollectedOnRoster(
 	return n;
 }
 
+/** Count collected pasteboards tagged with each club id (from collect-time `teamId`). */
+export function countCollectedByTeamId(
+	store: AlbumStore | null | undefined
+): Record<number, number> {
+	const counts: Record<number, number> = {};
+	for (const entry of Object.values(store?.collected ?? {})) {
+		const teamId = entry?.teamId;
+		if (teamId == null || !Number.isFinite(teamId)) {
+			continue;
+		}
+		counts[teamId] = (counts[teamId] ?? 0) + 1;
+	}
+	return counts;
+}
+
+export function countCollectedForTeam(
+	store: AlbumStore | null | undefined,
+	teamId: number | null | undefined
+): number {
+	if (teamId == null || !Number.isFinite(teamId)) {
+		return 0;
+	}
+	return countCollectedByTeamId(store)[teamId] ?? 0;
+}
+
+export type RosterAlbumFilter = 'all' | 'album';
+
+export type RosterPlayerLike = {
+	person?: { id?: number | null };
+} & Record<string, unknown>;
+
+/** Filter a loaded roster to collected cards only when `filter === 'album'`. */
+export function filterRosterPlayersByAlbum<T extends RosterPlayerLike>(
+	players: T[] | null | undefined,
+	store: AlbumStore | null | undefined,
+	filter: RosterAlbumFilter = 'all'
+): T[] {
+	const list = players ?? [];
+	if (filter !== 'album') {
+		return list;
+	}
+	return list.filter((row) => isCollected(store, row?.person?.id));
+}
+
 /** Completeness fill width for the roster pennant strip. */
 export function rosterCompletenessFillPercent(owned: number, total: number): string {
 	if (!(total > 0) || !(owned > 0)) {


### PR DESCRIPTION
## Summary
- **Full sheet / In album** filter on the open club (resets when switching teams); empty state with “Show full sheet” when nothing is collected yet.
- Checklist chips show a **per-club album count** badge (from collect-time `teamId` tags).
- README feature roll call + short product note: shareable `?team=` URLs; album stays on-device only.

## How to verify
- `npm run lint && npm run test:coverage && npm run build`
- Collect a few cards → checklist badge increments for that club
- Toggle **In album** → only collected cards; with zero collected → empty copy + **Show full sheet**
- Switch clubs → filter resets to Full sheet
- Live region announces filter changes


Made with [Cursor](https://cursor.com)