### PR TITLE
Fix filter contrast and club CTA copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # CARTOPHILES
 
-**Pasteboard album · Clubs · Late-50s gum card chrome**
+**Card album · Clubs · Late-50s gum card chrome**
 
 </div>
 
@@ -80,7 +80,7 @@ Per-franchise caps and fields: `--theme-*` in `src/styles/team-themes.css`. **Up
 | --- | ------------ |
 | **CLUBS** | MLB teams filtered to `sport.name === 'Major League Baseball'`; AL / NL sections + search; per-club album count badges |
 | **SHAREABLE CLUB** | `?team=<teamCode>` deep links (History API); refresh / share / back-forward restore the sheet |
-| **LOCAL ALBUM** | Collect pasteboards in the browser (`localStorage`); completeness is owned vs roster; Full sheet / In album filter |
+| **LOCAL ALBUM** | Collect cards in the browser (`localStorage`); completeness is owned vs roster; Full sheet / In album filter |
 | **ROSTER GRID** | One **1959-style** card per active player; team crest + theme on the front |
 | **FLIP** | Click / keyboard flip; back pulls bat/ball stats lines from batched people payload |
 | **TILT + FOIL** | Pointer tilt on the scene; optional WebGL foil path on a single “chase” card target |

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Per-franchise caps and fields: `--theme-*` in `src/styles/team-themes.css`. **Up
 | TAG | WHAT HAPPENS |
 | --- | ------------ |
 | **CLUBS** | MLB teams filtered to `sport.name === 'Major League Baseball'`; AL / NL sections + search; per-club album count badges |
-| **SHAREABLE CLUB** | `?team=<teamCode>` deep links (History API); refresh / share / back-forward restore the sheet |
-| **LOCAL ALBUM** | Collect cards in the browser (`localStorage`); completeness is owned vs roster; Full sheet / In album filter |
+| **SHAREABLE CLUB** | `?team=<teamCode>` deep links (History API); refresh / share / back-forward restore the club |
+| **LOCAL ALBUM** | Collect cards in the browser (`localStorage`); completeness is owned vs roster; All cards / In album filter |
 | **ROSTER GRID** | One **1959-style** card per active player; team crest + theme on the front |
 | **FLIP** | Click / keyboard flip; back pulls bat/ball stats lines from batched people payload |
 | **TILT + FOIL** | Pointer tilt on the scene; optional WebGL foil path on a single “chase” card target |
@@ -89,7 +89,7 @@ Per-franchise caps and fields: `--theme-*` in `src/styles/team-themes.css`. **Up
 | **CACHE** | Short-lived Axios cache adapter on the client |
 | **DARK NIGHT GAME** | `prefers-color-scheme: dark` retints `:root` in `tokens.css` (warmer cards under “lights”) |
 
-> **Product note:** Club URLs are shareable; your album stays on-device only (no account / database). Sharing `?team=bos` opens the Red Sox sheet — not someone else’s collection.
+> **Product note:** Club URLs are shareable; your album stays on-device only (no account / database). Sharing `?team=bos` opens the Red Sox cards — not someone else’s collection.
 
 ```
 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # CARTOPHILES
 
-**Pasteboard album · Club checklist · Late-50s gum card chrome**
+**Pasteboard album · Clubs · Late-50s gum card chrome**
 
 </div>
 
@@ -26,7 +26,7 @@ Same public feed for teams, roster, and player lines — errors stay visible, no
 
 ## ⚾ PROGRAM NOTES — **what this is, fast**
 
-> **Vue 3** SPA: `App.vue` is the whole **album shell** (masthead, checklist rail, felt, binder, roster deal). **Axios** + cache adapter batch `GET /people?personIds=…` for card backs. **Global look** lives in `src/styles/tokens.css` (newsprint, letterpress rules, album layers, card sheen) and `src/styles/team-themes.css` (`[data-theme]` on each **BaseballCard**). **`prefers-reduced-motion: reduce`** skips pack Lottie load + flying peel; short opacity fades only — same spirit as the arcade README, but the volume knob is **stadium organ**, not neon.
+> **Vue 3** SPA: `App.vue` is the whole **album shell** (masthead, clubs rail, felt, binder, roster deal). **Axios** + cache adapter batch `GET /people?personIds=…` for card backs. **Global look** lives in `src/styles/tokens.css` (newsprint, letterpress rules, album layers, card sheen) and `src/styles/team-themes.css` (`[data-theme]` on each **BaseballCard**). **`prefers-reduced-motion: reduce`** skips pack Lottie load + flying peel; short opacity fades only — same spirit as the arcade README, but the volume knob is **stadium organ**, not neon.
 >
 > **Dev** hits the API through **same-origin** `/teams` and `/people` via Vite → Express. **Production / Pages** can point `VITE_API_BASE` straight at MLB when CORS allows.
 
@@ -78,7 +78,7 @@ Per-franchise caps and fields: `--theme-*` in `src/styles/team-themes.css`. **Up
 
 | TAG | WHAT HAPPENS |
 | --- | ------------ |
-| **CLUB CHECKLIST** | MLB teams filtered to `sport.name === 'Major League Baseball'`; AL / NL sections + search; per-club album count badges |
+| **CLUBS** | MLB teams filtered to `sport.name === 'Major League Baseball'`; AL / NL sections + search; per-club album count badges |
 | **SHAREABLE CLUB** | `?team=<teamCode>` deep links (History API); refresh / share / back-forward restore the sheet |
 | **LOCAL ALBUM** | Collect pasteboards in the browser (`localStorage`); completeness is owned vs roster; Full sheet / In album filter |
 | **ROSTER GRID** | One **1959-style** card per active player; team crest + theme on the front |

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,7 @@
 						<p v-if="teamsLoading" class="album__status" role="status">
 							<span class="album__loading-row">
 								<span class="album__loading-copy">
-									Working the league sheet
+									Working the league
 									<span class="album__type-caret" aria-hidden="true"></span>
 								</span>
 								<span class="album__print-dots" aria-hidden="true">
@@ -170,7 +170,7 @@
 								v-if="!rosterLoading && selectedTeamId === null"
 								class="album__results-placeholder"
 							>
-								Pick a club to open the sheet.
+								Pick a club to see the cards.
 							</p>
 							<div
 								v-if="selectedTeamId !== null"
@@ -214,7 +214,7 @@
 												:aria-pressed="rosterAlbumFilter === 'all' ? 'true' : 'false'"
 												@click="setRosterAlbumFilter('all')"
 											>
-												Full sheet
+												All cards
 											</button>
 											<button
 												type="button"
@@ -285,7 +285,7 @@
 										class="album__results-empty-action"
 										@click="setRosterAlbumFilter('all')"
 									>
-										Show full sheet
+										Show all cards
 									</button>
 								</p>
 								<p
@@ -443,7 +443,7 @@ const teamsSectionsLayoutClass = computed(() => {
 /** Owned counts per club from collect-time teamId tags. */
 const albumCountByTeamId = computed(() => countCollectedByTeamId(albumStore.value));
 
-/** Roster rows after Full sheet / In album filter. */
+/** Roster rows after All cards / In album filter. */
 const displayedPlayers = computed(() =>
 	filterRosterPlayersByAlbum(players.value, albumStore.value, rosterAlbumFilter.value)
 );
@@ -456,7 +456,7 @@ const showAlbumFilterEmpty = computed(
 		displayedPlayers.value.length === 0
 );
 
-/** Completeness uses the full club sheet; filter only changes which cards render. */
+/** Completeness uses the full club roster; filter only changes which cards render. */
 const rosterOwnedCount = computed(() =>
 	countCollectedOnRoster(
 		albumStore.value,
@@ -482,7 +482,7 @@ const rosterLoadingHeadline = computed(() => {
 	if (rosterLoadStage.value === 'faces') {
 		return 'Mounting portraits…';
 	}
-	return 'Pulling the club sheet…';
+	return 'Loading the roster…';
 });
 
 /** Placeholder card-backs while the roster / people requests run */
@@ -902,7 +902,7 @@ function setRosterAlbumFilter(next) {
 				: `No cards in your album for the ${teamName.value} yet.`
 		);
 	} else {
-		setLiveMessage(`Showing the full sheet for the ${teamName.value}.`);
+		setLiveMessage(`Showing all cards for the ${teamName.value}.`);
 	}
 }
 
@@ -963,7 +963,7 @@ async function selectTeam(team, opts = {}) {
 	}
 
 	players.value = [];
-	setLiveMessage(`Pulling the sheet for ${team.name}.`);
+	setLiveMessage(`Loading cards for ${team.name}.`);
 	setRosterLoadStage('pulling');
 	setRosterLoading(true);
 
@@ -991,7 +991,7 @@ async function selectTeam(team, opts = {}) {
 			return;
 		}
 		players.value = [];
-		setLiveMessage(`Could not load the sheet for ${team.name}.`);
+		setLiveMessage(`Could not load cards for ${team.name}.`);
 	} finally {
 		if (requestId === rosterRequestId) {
 			setRosterLoading(false);
@@ -1050,7 +1050,7 @@ onMounted(() => {
 	teams.value = [];
 	teamsLoading.value = true;
 	teamsError.value = '';
-	liveRegionText.value = 'Opening the league sheet.';
+	liveRegionText.value = 'Loading clubs.';
 	http.get('teams')
 		.then((response) => {
 			const data = filterMajorLeagueBaseballTeams(response.data.teams || []).sort(
@@ -1061,7 +1061,7 @@ onMounted(() => {
 			const deepLinkCode = readTeamCodeFromLocation();
 			const deepLinkTeam = deepLinkCode ? findTeamByTeamCode(data, deepLinkCode) : undefined;
 			if (deepLinkTeam) {
-				liveRegionText.value = `Opening the sheet for ${deepLinkTeam.name}.`;
+				liveRegionText.value = `Loading cards for ${deepLinkTeam.name}.`;
 			} else if (deepLinkCode) {
 				liveRegionText.value = `No club on file for “${deepLinkCode}”.`;
 			} else {

--- a/src/App.vue
+++ b/src/App.vue
@@ -47,7 +47,7 @@
 					</div>
 					<h1 class="album__search--title">Clubs</h1>
 					<p class="app__title-subtitle">
-						American / National loop — one club, one roster. Pick your side and complete your run.
+						Pick a club, flip the pasteboards, and collect a few into your album.
 					</p>
 				</div>
 			</div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,11 +43,11 @@
 				</div>
 				<div class="app__title-text">
 					<div class="app__title-kicker-wrap">
-						<p class="app__title-kicker">Pasteboard album</p>
+						<p class="app__title-kicker">Card album</p>
 					</div>
 					<h1 class="album__search--title">Clubs</h1>
 					<p class="app__title-subtitle">
-						Pick a club, flip the pasteboards, and collect a few into your album.
+						Pick a club, flip the cards, and collect a few into your album.
 					</p>
 				</div>
 			</div>
@@ -279,7 +279,7 @@
 									v-if="showAlbumFilterEmpty"
 									class="album__results-empty album__results-empty--filter"
 								>
-									No pasteboards in your album for the {{ teamName }} yet.
+									No cards in your album for the {{ teamName }} yet.
 									<button
 										type="button"
 										class="album__results-empty-action"
@@ -292,7 +292,7 @@
 									v-else-if="!players.length"
 									class="album__results-empty"
 								>
-									No pasteboards on file for the {{ teamName }}.
+									No cards on file for the {{ teamName }}.
 								</p>
 								</div>
 								<Transition name="album-skel-fade">
@@ -365,7 +365,7 @@ const liveRegionText = ref('');
 const rosterLoading = ref(false);
 /** Client-only album (localStorage); no backend. */
 const albumStore = ref(readAlbumStore(typeof localStorage !== 'undefined' ? localStorage : null));
-/** 'all' | 'album' — which pasteboards to show for the open club. */
+/** 'all' | 'album' — which cards to show for the open club. */
 const rosterAlbumFilter = ref('all');
 /** 'idle' | 'pulling' | 'faces' — while a roster request is in flight */
 const rosterLoadStage = ref('idle');
@@ -899,7 +899,7 @@ function setRosterAlbumFilter(next) {
 		setLiveMessage(
 			n > 0
 				? `Showing ${n} ${n === 1 ? 'card' : 'cards'} in your album for the ${teamName.value}.`
-				: `No pasteboards in your album for the ${teamName.value} yet.`
+				: `No cards in your album for the ${teamName.value} yet.`
 		);
 	} else {
 		setLiveMessage(`Showing the full sheet for the ${teamName.value}.`);
@@ -980,7 +980,7 @@ async function selectTeam(team, opts = {}) {
 		}
 		players.value = nextPlayers;
 		if (empty) {
-			setLiveMessage(`No pasteboards listed for ${team.name}.`);
+			setLiveMessage(`No cards listed for ${team.name}.`);
 		} else {
 			setLiveMessage(
 				`Showing ${nextPlayers.length} ${nextPlayers.length === 1 ? 'card' : 'cards'} for ${team.name}.`
@@ -1020,7 +1020,7 @@ function syncTeamFromLocation(opts = {}) {
 			rosterRequestId += 1;
 			clearSelectedTeam();
 			setRosterLoading(false);
-			setLiveMessage('Club cleared. Pick a club to see the pasteboards.');
+			setLiveMessage('Club cleared. Pick a club to see the cards.');
 		}
 		return;
 	}
@@ -1067,7 +1067,7 @@ onMounted(() => {
 			} else {
 				liveRegionText.value =
 					data.length > 0
-						? `${data.length} clubs on file. Pick a club to see the pasteboards.`
+						? `${data.length} clubs on file. Pick a club to see the cards.`
 						: 'No teams available.';
 			}
 		})
@@ -1089,7 +1089,7 @@ onMounted(() => {
 <style>
 /*
  * Typography: tokens.css — Newsreader (UI body), Oswald (chrome labels), Bebas Neue (display h1/h2),
- * Archivo (cards / pasteboard type).
+ * Archivo (card type).
  * Motion: pack unwrap + card deal only; masthead / chrome / roster stay static (print + broadcast).
  */
 html {

--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@
 					<div class="app__title-kicker-wrap">
 						<p class="app__title-kicker">Pasteboard album</p>
 					</div>
-					<h1 class="album__search--title">Club checklist</h1>
+					<h1 class="album__search--title">Clubs</h1>
 					<p class="app__title-subtitle">
 						American / National loop — one club, one roster. Pick your side and complete your run.
 					</p>
@@ -170,7 +170,7 @@
 								v-if="!rosterLoading && selectedTeamId === null"
 								class="album__results-placeholder"
 							>
-								Open the checklist — pick a club to start your run.
+								Pick a club to start your run.
 							</p>
 							<div
 								v-if="selectedTeamId !== null"
@@ -1020,7 +1020,7 @@ function syncTeamFromLocation(opts = {}) {
 			rosterRequestId += 1;
 			clearSelectedTeam();
 			setRosterLoading(false);
-			setLiveMessage('Club cleared. Pick one from the checklist to see the pasteboards.');
+			setLiveMessage('Club cleared. Pick a club to see the pasteboards.');
 		}
 		return;
 	}
@@ -1067,7 +1067,7 @@ onMounted(() => {
 			} else {
 				liveRegionText.value =
 					data.length > 0
-						? `${data.length} clubs on file. Pick one from the checklist to see the pasteboards.`
+						? `${data.length} clubs on file. Pick a club to see the pasteboards.`
 						: 'No teams available.';
 			}
 		})
@@ -2903,9 +2903,10 @@ h2 {
 }
 
 .album__roster-filter-btn {
-	background: color-mix(in srgb, var(--color-surface-elevated, #f7f3ea) 92%, transparent);
-	border: 1px solid color-mix(in srgb, var(--color-text) 28%, transparent);
-	color: var(--color-text-muted);
+	/* Body text on elevated stock — aim for WCAG AA normal text (≥4.5:1). */
+	background: var(--color-surface-elevated);
+	border: 1px solid color-mix(in srgb, var(--color-text) 35%, transparent);
+	color: var(--color-text);
 	cursor: pointer;
 	font-family: var(--font-ui-heading);
 	font-size: 0.6875rem;
@@ -2933,14 +2934,24 @@ h2 {
 }
 
 .album__roster-filter-btn[aria-pressed='true'] {
-	background: color-mix(in srgb, var(--theme-heading, var(--color-ui-crimson)) 14%, var(--color-surface-elevated, #f7f3ea));
-	border-color: var(--theme-heading, var(--color-ui-crimson));
-	color: var(--theme-heading, var(--color-ui-crimson));
+	/* Selected via fill + weight + border — keep ink text for contrast (not crimson-on-cream). */
+	background: var(--color-surface-selected);
+	border-color: var(--color-ui-ink);
+	color: var(--color-text);
+	font-weight: 700;
 }
 
 @media (prefers-color-scheme: dark) {
 	.album__roster-filter-btn {
-		background: color-mix(in srgb, var(--color-surface-elevated, #1c1917) 80%, transparent);
+		background: var(--color-surface-elevated);
+		border-color: color-mix(in srgb, var(--color-text) 40%, transparent);
+		color: var(--color-text);
+	}
+
+	.album__roster-filter-btn[aria-pressed='true'] {
+		background: var(--color-surface-selected);
+		border-color: var(--color-ui-ink);
+		color: var(--color-text);
 	}
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -170,7 +170,7 @@
 								v-if="!rosterLoading && selectedTeamId === null"
 								class="album__results-placeholder"
 							>
-								Pick a club to start your run.
+								Pick a club to open the sheet.
 							</p>
 							<div
 								v-if="selectedTeamId !== null"

--- a/src/components/BaseballCard.vue
+++ b/src/components/BaseballCard.vue
@@ -4,18 +4,6 @@
 			class="card__shell"
 			:class="{ 'card__shell--collected': collected }"
 		>
-			<button
-				type="button"
-				class="card__collect"
-				:aria-pressed="collected ? 'true' : 'false'"
-				:aria-label="collectAriaLabel"
-				@click="onCollectClick"
-			>
-				<span class="card__collect-mark" aria-hidden="true">{{ collected ? 'IN' : '+' }}</span>
-				<span class="card__collect-label" aria-hidden="true">{{
-					collected ? 'Album' : 'Collect'
-				}}</span>
-			</button>
 			<div
 				ref="sceneRef"
 				class="card__scene"
@@ -62,6 +50,18 @@
 					/>
 				</div>
 			</div>
+			<button
+				type="button"
+				class="card__collect"
+				:aria-pressed="collected ? 'true' : 'false'"
+				:aria-label="collectAriaLabel"
+				@click="onCollectClick"
+			>
+				<span class="card__collect-mark" aria-hidden="true">{{ collected ? 'IN' : '+' }}</span>
+				<span class="card__collect-label" aria-hidden="true">{{
+					collected ? 'Album' : 'Collect'
+				}}</span>
+			</button>
 		</div>
 	</div>
 </template>
@@ -216,7 +216,7 @@ function onCollectClick() {
  * mis-composites 3D flips with this, remove .card__defer’s content-visibility.
  */
 .card__defer {
-	contain-intrinsic-block-size: 336px; /* ~5:6 at 280px max width */
+	contain-intrinsic-block-size: 372px; /* ~5:6 card + collect row */
 	/* auto skipped subtree decode/paint in some browsers with 3D cards + external images */
 	content-visibility: visible;
 	max-width: 280px;
@@ -224,14 +224,18 @@ function onCollectClick() {
 }
 
 .card__shell {
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
 	position: relative;
 	width: 100%;
 }
 
 .card__collect {
 	align-items: center;
-	background: color-mix(in srgb, var(--color-surface-elevated, #f7f3ea) 88%, var(--color-ui-crimson, #9b1c1c));
-	border: 1px solid color-mix(in srgb, var(--color-text) 28%, transparent);
+	align-self: stretch;
+	background: var(--color-surface-elevated);
+	border: 1px solid color-mix(in srgb, var(--color-text) 35%, transparent);
 	border-radius: 0;
 	box-shadow: 0 1px 0 color-mix(in srgb, var(--color-ink, #1c1917) 12%, transparent);
 	color: var(--color-text);
@@ -241,14 +245,13 @@ function onCollectClick() {
 	font-size: 0.625rem;
 	font-weight: 700;
 	gap: 0.28rem;
+	justify-content: center;
 	letter-spacing: 0.08em;
 	line-height: 1;
-	padding: 0.35rem 0.45rem;
-	position: absolute;
-	right: 0.35rem;
+	padding: 0.4rem 0.5rem;
+	position: relative;
 	text-transform: uppercase;
-	top: 0.35rem;
-	z-index: 4;
+	z-index: 1;
 }
 
 .card__collect:focus {
@@ -262,9 +265,10 @@ function onCollectClick() {
 }
 
 .card__collect[aria-pressed='true'] {
-	background: color-mix(in srgb, var(--theme-heading, var(--color-ui-crimson)) 18%, var(--color-surface-elevated, #f7f3ea));
-	border-color: var(--theme-heading, var(--color-ui-crimson));
-	color: var(--theme-heading, var(--color-ui-crimson));
+	background: var(--color-surface-selected);
+	border-color: var(--color-ui-ink);
+	color: var(--color-text);
+	font-weight: 700;
 }
 
 .card__collect-mark {
@@ -273,7 +277,7 @@ function onCollectClick() {
 }
 
 .card__collect-label {
-	max-width: 4.5rem;
+	max-width: 6rem;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/src/lib/albumCollection.ts
+++ b/src/lib/albumCollection.ts
@@ -150,7 +150,7 @@ export function countCollectedOnRoster(
 	return n;
 }
 
-/** Count collected pasteboards tagged with each club id (from collect-time `teamId`). */
+/** Count collected cards tagged with each club id (from collect-time `teamId`). */
 export function countCollectedByTeamId(
 	store: AlbumStore | null | undefined
 ): Record<number, number> {

--- a/src/lib/rosterLoad.ts
+++ b/src/lib/rosterLoad.ts
@@ -47,7 +47,7 @@ async function fetchPeopleByIds(http: RosterHttp, personIds: number[]) {
  * Load a club roster and batch-enrich with `/people` (same path as the checklist chips).
  * Rejects when the roster request fails; people failures degrade to empty `playerInfo`.
  *
- * @param opts.onRosterLoaded — called after a non-empty roster sheet arrives (before people batch)
+ * @param opts.onRosterLoaded — called after a non-empty roster arrives (before people batch)
  */
 export async function fetchEnrichedRoster(
 	http: RosterHttp,

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -5,7 +5,7 @@
  * prefers-color-scheme: dark flips these so you tune light/dark in one place.
  */
 :root {
-	/* App chrome: Newsreader (UI body / scorecard copy), Oswald (labels), Bebas (display), Archivo (pasteboards). */
+	/* App chrome: Newsreader (UI body / scorecard copy), Oswald (labels), Bebas (display), Archivo (cards). */
 	--font-ui: 'Newsreader', Georgia, 'Times New Roman', serif;
 	--font-ui-heading: 'Oswald', 'Arial Narrow', sans-serif;
 	--font-ui-display: 'Bebas Neue', 'Oswald', 'Arial Narrow', sans-serif;


### PR DESCRIPTION
## Summary
- **Full sheet / In album**: use `--color-text` on elevated/selected surfaces (selected via fill + weight + border) instead of muted or crimson-on-cream text that can fail WCAG AA.
- Empty state / live messages: “Pick a club…” instead of “Open the checklist…”.
- Masthead title **Clubs** (was Club checklist); README wording aligned.

## How to verify
- `npm run lint && npm run test:run && npm run build`
- Spot-check filter labels in light + dark with a contrast checker / axe
- Empty binder shows “Pick a club to start your run.”


Made with [Cursor](https://cursor.com)