### PR TITLE
Add Claude Code permission allowlist for common read-only commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git fetch *)",
+      "Bash(npm run lint)",
+      "Bash(npm run test:run)",
+      "Bash(npm run test:coverage)",
+      "Bash(npm run build)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with a `permissions.allow` list, cutting down approval prompts for `git fetch` and this repo's own CI-parity npm scripts (`lint`, `test:run`, `test:coverage`, `build`).
- Built by scanning recent Claude Code transcripts (this project + `caught-looking`) for frequent read-only commands, filtered to what's actually applicable to this repo's toolchain (no Go/Makefile/gcloud here) and cross-checked against what `definition-of-done`/`pr-ready` already require running.
- Nothing mutating or arbitrary-code-execution-capable was added (no `git push`/`add`/`commit`, no bare interpreters, no task-runner wildcards).

Stacked on #114 — base branch is `docs/agents-md-claude-code-support`, not `main`.

## Test plan
- [x] Confirmed no `.claude/settings.json` existed previously (this creates it fresh)
- [x] Verified each pattern against Claude Code's already-auto-allowed command list to avoid redundant rules
- [ ] Work a session in this repo and confirm fewer permission prompts for `git fetch` / `npm run lint` / `npm run build` / `npm run test:run` / `npm run test:coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)