### PR TITLE
Auto-merge Dependabot PRs for patch/minor bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Enable auto-merge for patch/minor bumps
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Enable auto-merge for patch/minor bumps


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/dependabot-auto-merge.yml`: classifies each Dependabot PR via the official `dependabot/fetch-metadata` action, then enables GitHub's native auto-merge (squash) for `semver-patch`/`semver-minor` bumps only. Major bumps are left alone for manual review.
- Pairs with branch protection just enabled on `main` (`unit-tests` required, strict, enforced for admins) — auto-merge will not complete until CI is green.
- $0: no external service, GitHub-native auto-merge + unlimited Actions minutes on this public repo.

Repo settings changed as part of this (not in this diff, applied directly via API, confirmed with you first):
- `main` branch protection: require `unit-tests` check, strict (branch must be up to date), `enforce_admins: true`
- Repo setting `allow_auto_merge: true`

## Test plan
- [x] YAML validated
- [x] `npm run format:check` passes
- [ ] Next Dependabot patch/minor PR auto-merges after CI passes; next major bump PR does not