### PR TITLE
Add Lighthouse CI on PRs

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,44 @@
+name: Lighthouse CI
+
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - name: Build
+        run: npm run build
+        env:
+          VITE_API_BASE: https://statsapi.mlb.com/api/v1
+      - name: Run Lighthouse CI
+        id: lighthouse
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./.lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+      - name: Comment PR with report links
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const links = JSON.parse('${{ steps.lighthouse.outputs.links }}' || '{}');
+            const rows = Object.entries(links).map(([url, report]) => `- [${url}](${report})`);
+            const body = rows.length
+              ? ['### Lighthouse CI report', '', ...rows].join('\n')
+              : '### Lighthouse CI report\n\nNo report links returned (check the job log).';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 /dist
 /coverage
+/.lighthouseci
 
 # local env files
 .env.local

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,11 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "numberOfRuns": 1
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/lighthouse.yml`: builds the app, runs Lighthouse against the built `dist/` via `treosh/lighthouse-ci-action`, uploads to free temporary-public-storage, and comments the report link on the PR.
- Informational only — no score thresholds/`assert` config, so it can't block a merge.
- $0: no external LHCI server, no paid hosting, unlimited Actions minutes on this public repo.
- Ties into the existing `bundle-performance` and `accessibility-a11y` skills — this gives them a concrete number to check against instead of "run Lighthouse manually."

Verified locally end-to-end before pushing (`npx @lhci/cli healthcheck` + `collect` against the real production build): **performance 46, accessibility 98, best-practices 100, seo 90**. The low performance score isn't introduced by this PR — it matches the large-chunk warning `bundle-performance` already documents (500KB+ main chunk); this workflow just makes that visible per-PR instead of only on manual investigation.

## Test plan
- [x] Verified end-to-end locally (build → serve → Lighthouse collect), real scores captured above
- [x] YAML/JSON validated, `npm run format:check` passes
- [ ] Confirm the PR comment posts correctly with real GitHub Actions permissions (local run can't exercise the comment step)