### PR TITLE
Port dependabot-triage, pr-summary-draft, coverage-gap-diagnosis skills

### DIFF
--- a/.cursor/rules/baseball-collection.mdc
+++ b/.cursor/rules/baseball-collection.mdc
@@ -46,3 +46,6 @@ Read `.cursor/skills/<name>/SKILL.md` when the task fits:
 - **`accessibility-a11y`** — keyboard, ARIA, reduced motion
 - **`bundle-performance`** — size report, Lottie/chunk weight
 - **`doc-writer`** — README / JSDoc (keep palette tables in sync with `tokens.css`)
+- **`dependabot-triage`** — classify open Dependabot PRs auto-merge didn't handle (majors, CI-red)
+- **`pr-summary-draft`** — drafts a why-first PR Summary / How-to-verify from the actual diff
+- **`coverage-gap-diagnosis`** — names untested branches for changed files, not just a percentage

--- a/.cursor/skills/coverage-gap-diagnosis/SKILL.md
+++ b/.cursor/skills/coverage-gap-diagnosis/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: coverage-gap-diagnosis
+description: >-
+  Reads local coverage output for the files changed on this branch and names
+  the specific untested branches/error paths, instead of a bare percentage.
+  Use when coverage is close to a threshold, dropped, or the user asks
+  what's undertested, to diagnose a coverage gap, or why coverage failed.
+---
+
+# Coverage gap diagnosis (baseball-collection)
+
+CI's coverage step (`npm run test:coverage` → Cobertura → job summary / PR comment) only shows
+an aggregate percentage against `vite.config.mjs`'s thresholds (**lines 95, statements 95,
+branches 82, functions 85**). It never says which lines, in which changed files, are actually
+untested. This skill does that, locally, before or instead of waiting on the CI comment.
+
+## Order of work
+
+### 1. Find the changed source files
+
+```bash
+git diff --name-only main...HEAD -- 'src/**/*.ts' 'src/**/*.vue' 'lib/**/*.cjs' \
+  | grep -v -e '\.test\.ts$' -e '\.test\.mjs$'
+```
+
+Exclude test files themselves. Also check `vite.config.mjs`'s `test.coverage.exclude` list —
+`src/App.vue`, `src/http-common.ts`, `src/lib/cardFoilWebgl.ts`, `src/lib/cardFoilDom.ts`,
+`src/lib/useCardTilt.ts`, `src/lib/useBinderPennantParallax.ts`, and the foil/Lottie components
+are deliberately excluded from coverage measurement (WebGL/DOM/animation code covered indirectly
+via UI, not unit tests) — a gap there isn't a gap this skill (or CI) can see.
+
+### 2. Generate coverage
+
+```bash
+npm run test:coverage
+```
+
+Vitest (v8 provider) prints a per-file **text** table to the terminal with an **`Uncovered Line
+#s`** column, and writes `coverage/` (`html`, `cobertura-coverage.xml`) for deeper inspection.
+
+### 3. Find uncovered lines in the changed files
+
+Read the terminal table's row for each changed file, or open `coverage/index.html` /
+`coverage/<path>/index.html` in a browser for the annotated source (red = uncovered).
+
+### 4. Describe what's untested, not just where
+
+Read the actual source at each uncovered range. Say what _behavior_ is missing a test — an error
+branch, a specific prop/state combination, an empty-state render, an MLB API failure path — not
+just "lines 58–83 uncovered." Cross-reference `test-generator`'s coverage checklist (creation/
+mount, happy path, edge cases, async, emits, HTTP success/failure) — if the uncovered range is
+the HTTP-failure branch specifically, say so.
+
+### 5. Report
+
+One list: file:lines → what's untested → the specific missing test case in `test-generator`
+terms. This skill diagnoses; it doesn't write the tests unless asked — offer to, don't assume.
+
+## Anti-patterns
+
+- Reporting bare percentages or raw line numbers with no description of the missing behavior —
+  that's what the CI coverage comment already gives you; this skill exists to go further.
+- Flagging gaps in files the branch didn't touch (noise) — scope to the diff.
+- Flagging gaps in files `vite.config.mjs` deliberately excludes from coverage as if they were
+  measurable gaps.
+- Writing test code without being asked.
+
+## Reference
+
+- `vite.config.mjs` — `test.coverage.thresholds` / `exclude`.
+- `test-generator` — the coverage checklist this diagnoses against.
+- Full pre-PR flow: **`pr-ready`** skill.

--- a/.cursor/skills/dependabot-triage/SKILL.md
+++ b/.cursor/skills/dependabot-triage/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: dependabot-triage
+description: >-
+  Reviews open Dependabot PRs (npm, GitHub Actions) that dependabot-auto-merge
+  didn't already merge, reads each one's embedded changelog and required CI
+  status to classify risk, and merges only the PRs the user explicitly names.
+  Use when asked to review or triage Dependabot PRs, do the weekly dependency
+  review, or check the Dependabot backlog.
+---
+
+# Dependabot triage (baseball-collection)
+
+`.github/dependabot.yml` opens weekly PRs across two ecosystems (npm, GitHub Actions — both
+ungrouped, capped at 10 open each). `.github/workflows/dependabot-auto-merge.yml` already
+auto-merges **patch/minor** bumps once the required `unit-tests` check is green — so by the time
+you run this skill, what's actually sitting in the backlog is the harder cases: **major** bumps
+(never auto-merged), anything CI-red, and anything the auto-merge workflow hasn't gotten to yet.
+This skill reads and classifies those; merging still requires the user to name which PRs.
+
+## Order of work
+
+### 1. List open Dependabot PRs
+
+```bash
+gh pr list --author "app/dependabot" --limit 100 --json number,title,labels,createdAt,statusCheckRollup
+```
+
+`gh pr list` defaults to 30 results — the two ecosystems' combined cap (10 each) already sits at
+that boundary, and Dependabot **security updates** open outside the configured cap, so an unset
+`--limit` can silently truncate the backlog with no warning. Always pass `--limit`.
+
+If there are none open, say so and stop — nothing to triage.
+
+### 2. Gather signal per PR
+
+- **Ecosystem / bump shape** from the title and labels: `github_actions` or `npm`
+  (`Bump <package> from X to Y`) — see `.github/dependabot.yml`.
+- **Required CI only** — this repo's only merge-blocking check is **`unit-tests`** (runs
+  `format:check`, `lint`, `test:coverage`, `build` — see `pull-request-tests.yml` and the
+  `pr-ready` skill). `Analyze (actions)` / `Analyze (javascript-typescript)` (CodeQL) and
+  `lighthouse` are informational; ignore their state when judging mergeability.
+- **Changelog** — `gh pr view <n> --json body`. Dependabot embeds the release notes in a
+  collapsible `<details>` block. Scan for:
+  - Security signals: `CVE`, `GHSA`, "security fix" — treat as **Security** regardless of size.
+  - Breaking signals: `[BREAKING]`/`[CHANGE]` entries describing removed/renamed APIs, or a
+    "minimum required Node version" bump.
+  - Otherwise routine (bugfixes, features, docs).
+
+### 3. Classify each PR
+
+Evaluate in this order — first match wins:
+
+1. **Security** — changelog/advisory references a CVE/GHSA or explicit security fix. Flag first,
+   regardless of ecosystem or bump size; recommend merging promptly once `unit-tests` is green.
+2. **Needs a look** — any of:
+   - A **major** version bump (or a 0.x → 1.x jump) — `dependabot-auto-merge` never touches these.
+   - A breaking/minimum-version changelog entry (see step 2).
+   - `unit-tests` red.
+   - Still open after a few days despite being patch/minor — worth checking why auto-merge hasn't
+     picked it up (e.g. a merge conflict, or `unit-tests` never went green).
+3. **Low risk** — a patch/minor bump, `unit-tests` green, no breaking/minimum-version changelog
+   entries. In the normal case `dependabot-auto-merge` already merges these before you ever see
+   them; a tier-3 PR still open usually means something's blocking it (see tier 2's last bullet).
+
+### 4. Report — do not merge yet
+
+One table: PR #, package, bump, tier, one-line why (cite the changelog line that drove the
+classification, not just "looks fine"). Stop here by default.
+
+### 5. Merge only what the user names
+
+```bash
+gh pr merge <number> --squash
+```
+
+Matches the repo's existing convention (squash — see `git log`). Merge only PRs the user
+explicitly names in their reply (e.g. "merge #212 and #214"). Do not batch-merge an entire tier
+on your own initiative — per `AGENTS.md`, never merge a PR unless asked.
+
+## Anti-patterns
+
+- Merging anything the user didn't explicitly name this session.
+- Treating a red **optional** check (CodeQL/Lighthouse) as blocking, or a green one as sufficient
+  to skip reading the changelog.
+- Classifying by semver label alone without reading the embedded release notes — they're already
+  in the PR body; use them.
+- Assuming `dependabot-auto-merge` already handled everything patch/minor without checking —
+  auto-merge can stall on a merge conflict or a flaky `unit-tests` run.
+
+## Reference
+
+- Config: `.github/dependabot.yml`. Auto-merge: `.github/workflows/dependabot-auto-merge.yml`.
+- Required-check source: `.github/workflows/pull-request-tests.yml` (`unit-tests` job).

--- a/.cursor/skills/pr-summary-draft/SKILL.md
+++ b/.cursor/skills/pr-summary-draft/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pr-summary-draft
+description: >-
+  Drafts a why-first PR Summary and How-to-verify section by reading the
+  actual diff and commits on the current branch, not just which paths
+  changed. Use when opening a PR, updating a PR description, asked to draft
+  a PR summary, or when the user asks what changed and why on this branch.
+---
+
+# PR summary draft (baseball-collection)
+
+`.github/pull_request_template.md` has two sections — **Summary** and **How to verify** — and
+nothing scaffolds them automatically in this repo. Left to a generic pass, that produces a file
+list (`Changed src/App.vue, src/lib/rosterLoad.ts`) instead of the _why_. This skill reads the
+real diff and writes the Summary a human reviewer would actually want.
+
+## Order of work
+
+### 1. Read the actual change, not just file names
+
+```bash
+git diff main...HEAD          # or the PR's base branch if not main
+git log --oneline main...HEAD
+```
+
+Read the diff content for the changed files — hunks, not just a file list. Prioritize files that
+changed _behavior_ (components, `src/lib/`, `server.js`, `lib/`, config) over mechanical diffs
+(formatting-only, generated/lockfile changes).
+
+### 2. Identify the why
+
+Look for the motivation in, roughly this priority order:
+
+1. What the conversation/task that produced this branch was actually trying to fix or add.
+2. Commit messages, if they explain intent (not just "wip" / "fix").
+3. What the diff implies: a bug fix (what broke, for whom), a new capability (what it unlocks),
+   a refactor (what got harder to maintain and why this fixes it).
+
+If the diff's purpose is genuinely ambiguous — e.g. a mixed-bag branch, or a change whose intent
+isn't evident from code or conversation — ask the user rather than inventing a plausible-sounding
+motivation. A wrong guess is worse than a question.
+
+### 3. Write the Summary
+
+Follow `.github/pull_request_template.md` and the **pr-ready** skill's guidance exactly:
+
+- Lead with **why** (motivation / problem), then what changed for users, API, or data.
+- 1–3 short bullets. Do not stop at a file list or restate commit subjects.
+- Weak: `Update BaseballCard.vue and CardFoilGl.vue.`
+- Stronger: `Foil shimmer was recalculating on every scroll frame even when the card was off
+screen; gate it behind an IntersectionObserver so idle cards stop costing paint time.`
+
+### 4. Write How to verify
+
+User-facing steps: UI paths to exercise (team picker, roster deal, card flip, album collection),
+expected before/after behavior, or the commands run (`lint` / `test:coverage` / `build` — see
+`pr-ready`). Use `N/A` for tooling-only changes.
+
+### 5. Apply it
+
+- **New PR**: `gh pr create --title "..." --body "$(cat <<'EOF' ... EOF)"` with the Summary and
+  How to verify sections filled in. Only create the PR if the user asked for one.
+- **Existing PR**: `gh pr edit <number> --body-file <file>` — read the current body first
+  (`gh pr view <number> --json body`) before overwriting it.
+
+## Anti-patterns
+
+- Summaries that restate the diff (`Changed X.vue, Y.ts`) instead of explaining motivation.
+- Guessing "why" when it isn't evident from the diff, commits, or conversation — ask instead.
+- Opening, editing, or pushing a PR without being asked.
+
+## Reference
+
+- Template: `.github/pull_request_template.md`.
+- Full pre-PR flow: **`pr-ready`** skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,11 @@ symlink to the same files, auto-invoked by either tool based on the task):
 - `bundle-performance` — size report, Lottie/chunk weight
 - `doc-writer` — README / JSDoc / inline comments (keep palette tables in sync with
   `tokens.css`)
+- `dependabot-triage` — classify open Dependabot PRs that auto-merge didn't already handle
+  (majors, CI-red); merges only what's explicitly named
+- `pr-summary-draft` — drafts a why-first PR Summary / How-to-verify from the actual diff
+- `coverage-gap-diagnosis` — names the specific untested branches for files changed on this
+  branch, not just a bare percentage
 
 ## Constraints — do not
 


### PR DESCRIPTION
## Summary
- Ports 3 skills from `danibsheehan/caught-looking`, adapted for this repo's actual stack rather than copied verbatim:
  - `dependabot-triage` — classifies open Dependabot PRs by risk (Security / Needs a look / Low risk), merges only what's named. Explicitly scoped around `dependabot-auto-merge.yml` (#118) already handling patch/minor bumps — this is for what's left: majors, CI-red, security.
  - `pr-summary-draft` — drafts a why-first PR Summary/How-to-verify from the real diff, following `.github/pull_request_template.md`.
  - `coverage-gap-diagnosis` — reads local `test:coverage` output for changed files and names the specific untested behavior, using the real thresholds from `vite.config.mjs` (lines 95, statements 95, branches 82, functions 85) and its actual `exclude` list, not invented numbers.
- Updates `AGENTS.md` and `.cursor/rules/baseball-collection.mdc`'s skill lists together, per the drift-guard constraint added in #114.
- `.claude/skills` picks these up automatically via the existing directory symlink — no separate wiring.
- $0: pure skill files, only consume your subscription quota when you actively invoke Claude Code/Cursor — same model as the 8 skills already in this repo.

## Test plan
- [x] `npm run format:check`, `npm run lint`, `npm run test:run` all pass
- [x] Confirmed `.claude/skills/{dependabot-triage,pr-summary-draft,coverage-gap-diagnosis}` resolve through the symlink
- [ ] Next dependency-review session, confirm `dependabot-triage` correctly identifies which PRs auto-merge already handled