### PR TITLE
Lazy-load lottie-web to shrink the critical-path JS bundle

### DIFF
--- a/src/components/AlbumPackLottie.vue
+++ b/src/components/AlbumPackLottie.vue
@@ -9,7 +9,6 @@
 
 <script setup>
 import { ref, watch, onBeforeUnmount, nextTick } from 'vue';
-import lottie from 'lottie-web';
 
 const props = defineProps({
   dealPhase: { type: String, required: true },
@@ -94,7 +93,12 @@ async function loadAndPlay() {
   }
 
   try {
-    const res = await fetch(packJsonUrl);
+    /* Fetch the comp JSON and the lottie-web player chunk together — neither blocks the other,
+       and the player never downloads at all for the reduced-motion path above. */
+    const [res, { default: lottie }] = await Promise.all([
+      fetch(packJsonUrl),
+      import('lottie-web'),
+    ]);
     if (!res.ok) {
       throw new Error(`lottie fetch ${res.status}`);
     }


### PR DESCRIPTION
## Summary

- PR #119's Lighthouse CI run flagged a performance score of 46, tracing to the "chunks larger than 500 kB" build warning: everything shipped as a single main JS chunk.
- `lottie-web` (used only for the wax-pack-opening animation) was statically imported into `AlbumPackLottie.vue` → `App.vue`, so its full weight loaded on every page visit — even for `prefers-reduced-motion` users, who never trigger the animation at all.
- Switched to a dynamic `import('lottie-web')`, run in parallel with the existing pack JSON `fetch` via `Promise.all` so neither blocks the other. It's placed after the existing reduced-motion check, so reduced-motion users still never download it.

**Before → after** (`npm run build:report`):

| | raw | gzip |
|---|---|---|
| Main JS chunk | 502.68 kB → 164.27 kB | 139.93 kB → 60.02 kB |
| `lottie-web` (new chunk, loads on pack-open only) | — → 299.40 kB | — → 75.39 kB |

The "chunks larger than 500 kB" Vite build warning is gone. No logic changed — same animation, same reduced-motion gating, just loaded on demand instead of eagerly.

## How to verify

- `npm run format:check` / `npm run lint` / `npm run test:coverage` (105 tests, coverage thresholds met) / `npm run build` all pass.
- UI: open a team, deal the pack — animation plays exactly as before. With `prefers-reduced-motion: reduce` (OS setting or DevTools emulation), pack opening still skips straight to the static grid.
- Network panel: `lottie-web`'s JS chunk only requests when a pack is actually opened, not on initial page load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)