### PR TITLE
Load Google Fonts stylesheet non-blocking

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,20 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Bebas+Neue&family=Newsreader:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Oswald:wght@500;600;700&display=swap"
-      rel="stylesheet"
+      onload="
+        this.onload = null;
+        this.rel = 'stylesheet';
+      "
     />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Bebas+Neue&family=Newsreader:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Oswald:wght@500;600;700&display=swap"
+      />
+    </noscript>
     <title>Cartophiles</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary

- PR #121's Lighthouse CI report (post lottie lazy-load, score 46 → 74) flagged **render-blocking-resources** at ~1,540 ms of estimated savings — the remaining biggest opportunity.
- The Google Fonts stylesheet in `index.html` (Archivo, Bebas Neue, Newsreader, Oswald) was a synchronous `<link rel="stylesheet">`, blocking first paint until it resolved from a third-party origin.
- Switched to the standard preload+swap pattern: `rel="preload" as="style"` with an `onload` handler that flips it to `rel="stylesheet"` once fetched, plus a `<noscript>` fallback for JS-disabled clients. Same fonts, same `display=swap` behavior — just no longer blocking render.

## How to verify

- `npm run format:check` / `npm run lint` / `npm run test:coverage` (105 tests, coverage thresholds met) / `npm run build` all pass.
- `npm run preview`: confirm the built `index.html` serves the `preload`/`onload`/`noscript` markup and fonts still render correctly (Newsreader body copy, Oswald labels, Bebas Neue display, Archivo on cards).
- Lighthouse CI will re-run on this PR — compare `render-blocking-resources` savings and overall performance score against PR #121's baseline (74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)