### PR TITLE
Group Dependabot npm minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
-    # Scans .github/workflows (and root action manifests).
+    # Scans .github/workflows (and root action manifests). Keep ungrouped so
+    # Action SHA/tag bumps stay reviewable one at a time.
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary
- npm minor/patch bumps now land in Dependabot's `npm-minor-and-patch` group instead of one PR per package
- Cuts down the number of individual PRs `dependabot-auto-merge.yml` has to process each week; GitHub Actions updates stay ungrouped so SHA/tag bumps remain reviewable one at a time

## How to verify
N/A — config only, effect shows up on the next Dependabot run.