### PR TITLE
Auto-apply PR labels by changed path

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,29 @@
+javascript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/**'
+          - 'server.js'
+          - 'lib/**'
+          - 'scripts/**'
+          - '*.mjs'
+          - '*.cjs'
+          - 'vite.config.ts'
+          - 'eslint.config.js'
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'README.md'
+          - 'AGENTS.md'
+          - 'CLAUDE.md'
+          - '*.md'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'package.json'
+          - 'package-lock.json'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          sync-labels: true


### PR DESCRIPTION
## Summary
- The repo already has `javascript` / `github_actions` / `documentation` / `dependencies` labels defined but nothing applies them to PRs
- Adds `actions/labeler` + `.github/labeler.yml` mapping those labels to changed-file paths (`src/**`+`server.js`+`lib/**` -> javascript, `.github/**` -> github_actions, `README.md`/`*.md` -> documentation, `package.json`/`package-lock.json` -> dependencies)
- Uses `pull_request_target` (standard for `actions/labeler`) since it needs write access to add labels and never checks out or runs PR-authored code

## How to verify
Open a PR touching e.g. `src/` and confirm the `javascript` label gets applied automatically.