### PR TITLE
Skip draft-PR CI runs and cap job runtime

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -8,7 +8,9 @@ permissions:
 
 jobs:
   lighthouse:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -17,7 +17,9 @@ concurrency:
 
 jobs:
   unit-tests:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7


### PR DESCRIPTION
## Summary
- `unit-tests` (pull-request-tests.yml) and `lighthouse` (lighthouse.yml) jobs now skip on draft PRs instead of running the full suite, saving CI minutes until a PR is marked ready
- Adds `timeout-minutes` to both jobs so a hung runner can't run indefinitely

Stacked on #126 (SHA pinning) since both touch the same job blocks in these two files — merge that one first.

## How to verify
Open a draft PR touching a file that would normally trigger these workflows and confirm both jobs are skipped (not just green) until marked ready for review.