### PR TITLE
Add Automation section; harden auto-merge to the grouped PR only

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,3 +1,6 @@
+# Auto-merges only the grouped npm-minor-and-patch Dependabot PR once required checks
+# pass. Ungrouped npm bumps (majors) and GitHub Actions bumps stay manual — they carry
+# more upgrade risk than a pre-grouped, semver-minor-or-patch bump does.
 name: Dependabot auto-merge
 
 on: pull_request
@@ -16,10 +19,8 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Enable auto-merge for patch/minor bumps
-        if: >
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+      - name: Enable auto-merge for npm-minor-and-patch group
+        if: steps.metadata.outputs.dependency-group-name == 'npm-minor-and-patch'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,10 @@ symlink to the same files, auto-invoked by either tool based on the task):
 - **Add unsolicited README/docs changes or drive-by refactors** on unrelated code — keep diffs
   focused.
 - **Commit secrets** (`.env*`, credentials).
-- **Amend or force-push**, or **open/push/merge a PR**, unless the user explicitly asks.
+- **Amend or force-push**, or **open/push/merge a PR**, unless the user explicitly asks. (See
+  README's **Automation** section for this repo's one standing exception — grouped Dependabot
+  auto-merge — and the read-only, cross-repo `weekly-project-update` routine, defined in
+  `danibsheehan/portfolio-automation`, that opens PRs *elsewhere*, never here.)
 
 ## Definition of done
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ symlink to the same files, auto-invoked by either tool based on the task):
 - **Amend or force-push**, or **open/push/merge a PR**, unless the user explicitly asks. (See
   README's **Automation** section for this repo's one standing exception — grouped Dependabot
   auto-merge — and the read-only, cross-repo `weekly-project-update` routine, defined in
-  `danibsheehan/portfolio-automation`, that opens PRs *elsewhere*, never here.)
+  `danibsheehan/portfolio-automation`, that opens PRs _elsewhere_, never here.)
 
 ## Definition of done
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,30 @@ Tests live next to sources: `src/**/*.test.ts`, `lib/**/*.test.mjs` (see `vite.c
 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 ```
 
+## ⚾ AUTOMATION — **what runs on its own**
+
+**In plain English:** one narrow decision merges itself (a Dependabot patch/minor bump once CI
+is green); everything else — triage, docs, features — is a person or an AI assistant doing work
+someone asked for, reviewed before it ships.
+
+- **Auto-merge** ([`dependabot-auto-merge.yml`](.github/workflows/dependabot-auto-merge.yml)) —
+  merges the grouped `npm-minor-and-patch` Dependabot PR once required checks pass. Same scoping
+  as `caught-looking`'s equivalent workflow. Ungrouped npm bumps (majors), GitHub Actions bumps,
+  and anything CI doesn't clear stay manual.
+- **`dependabot-triage`** skill — ported from `caught-looking`, available on request to classify
+  the Dependabot backlog by risk. Not on a schedule here yet — run it manually when the backlog
+  needs a look.
+- **CodeQL / security scanning** — not configured in this repo yet.
+- **Cross-repo, read-only**: a scheduled Claude Code routine, defined in
+  [`danibsheehan/portfolio-automation`](https://github.com/danibsheehan/portfolio-automation)'s
+  [`weekly-project-update`](https://github.com/danibsheehan/portfolio-automation/blob/main/.cursor/skills/weekly-project-update/SKILL.md)
+  skill, reads this repo once a week (never writes to it) and — only when there's something
+  people-relevant to report — opens a PR against
+  [danibsheehan.github.io](https://github.com/danibsheehan/danibsheehan.github.io) updating this
+  project's page. See
+  [`portfolio-automation`'s README](https://github.com/danibsheehan/portfolio-automation#autonomy-boundary)
+  for the full autonomy boundary (it opens, never merges).
+
 ## ⚾ PERFORMANCE CHECKLIST — **optional, for regressions**
 
 1. **Lighthouse** — Performance (mobile + desktop): LCP, TBT, dependency tree.


### PR DESCRIPTION
## Summary
- Adds an **Automation** section to README.md documenting what runs on its own: grouped Dependabot auto-merge, the on-request `dependabot-triage` skill, and the read-only cross-repo `weekly-project-update` routine (defined in `danibsheehan/portfolio-automation`) that opens portfolio PRs elsewhere but never touches this repo.
- **Fixes `dependabot-auto-merge.yml`**: it was gating on `update-type == semver-patch/minor` alone, which could auto-merge an *ungrouped* patch/minor bump too — not just the grouped `npm-minor-and-patch` PR. Now scoped to `dependency-group-name == 'npm-minor-and-patch'`, matching `caught-looking`'s equivalent workflow.
- Adds a matching one-line pointer in AGENTS.md's PR constraint.

## How to verify
- Read the updated workflow condition against [caught-looking's equivalent](https://github.com/danibsheehan/caught-looking/blob/main/.github/workflows/dependabot-auto-merge.yml) for parity.
- Docs-only for README/AGENTS.md changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)